### PR TITLE
fix: 0x09 byte incompatibility with the specification

### DIFF
--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -561,7 +561,10 @@ class MQTTClient:
         else:
             reply_topic = f"_zmqtt/reply/{os.urandom(16).hex()}"
 
-        corr = (properties.correlation_data if properties is not None else None) or os.urandom(16)
+        if properties is not None and properties.correlation_data is not None:
+            corr = properties.correlation_data
+        else:
+            corr = os.urandom(16)
 
         if properties is not None:
             req_props = dataclasses.replace(


### PR DESCRIPTION
Since the MQTT specification states that `correlation_data` can be empty, we should not call `os.random(16)`