### PR TITLE
fix: declare typing_extensions dependency for Python < 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     { name = "borisalekseev", email = "i.borisalekseev@gmail.com" }
 ]
 requires-python = ">=3.10"
-dependencies = []
+dependencies = ["typing_extensions>=4.4; python_version < '3.11'"]
 keywords = ["mqtt", "mqtt5", "iot", "python-mqtt", "zmqtt"]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/src/zmqtt/_internal/_compat.py
+++ b/src/zmqtt/_internal/_compat.py
@@ -6,6 +6,13 @@ import sys
 from collections.abc import AsyncGenerator
 
 if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+__all__ = ("Self", "defer_cancellation")
+
+if sys.version_info >= (3, 11):
 
     @contextlib.asynccontextmanager
     async def defer_cancellation() -> AsyncGenerator[None, None]:

--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -10,9 +10,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
 from typing import Final, Literal, Protocol, overload
 
-from typing_extensions import Self
-
-from zmqtt._internal._compat import defer_cancellation
+from zmqtt._internal._compat import Self, defer_cancellation
 from zmqtt._internal.packets.auth import Auth
 from zmqtt._internal.packets.connect import Connect
 from zmqtt._internal.packets.properties import (

--- a/uv.lock
+++ b/uv.lock
@@ -2199,8 +2199,11 @@ wheels = [
 
 [[package]]
 name = "zmqtt"
-version = "0.0.1a5"
+version = "0.0.5"
 source = { editable = "." }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -2223,6 +2226,7 @@ docs = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.4" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
`pip install zmqtt` produces a package that does not import: `client.py` does an unconditional `from typing_extensions import Self` while `dependencies = []`. It works on a dev machine only by accident — whenever some other package happens to pull `typing_extensions` in transitively — and CI stays green for the same reason (the dev group installs it).

## Symptom

Clean production image — `pip install zmqtt`, no dev extras, a slim base without anything that would drag `typing_extensions` in:

```console
$ python3 -m venv venv && venv/bin/pip install zmqtt
$ venv/bin/python -c "import zmqtt"
Traceback (most recent call last):
  ...
  File ".../site-packages/zmqtt/client.py", line 13, in <module>
    from typing_extensions import Self
ModuleNotFoundError: No module named 'typing_extensions'
```

## Cause

- `src/zmqtt/client.py` — `from typing_extensions import Self`, unconditional (not under `TYPE_CHECKING`, no version guard);
- `pyproject.toml` — `dependencies = []`.

## What this PR does

On 3.11+ `Self` is in the stdlib, so the version-gated import lives in `_internal/_compat.py` — next to the existing `defer_cancellation` shim, which already guards on `sys.version_info` — and `client.py` imports it from there. The dependency is declared only where it is actually needed:

```toml
dependencies = ["typing_extensions>=4.4; python_version < '3.11'"]
```

## Verification

Clean 3.12 venv, `pip install .` then `import zmqtt` — OK, with no `typing_extensions` present. Full suite, `ruff check` (select=ALL) and `mypy --strict` green.

<details><summary>Reproduction</summary>

```sh
python3 -m venv /tmp/zmqtt-clean
/tmp/zmqtt-clean/bin/pip install --quiet zmqtt
/tmp/zmqtt-clean/bin/pip list          # zmqtt present, typing_extensions absent
/tmp/zmqtt-clean/bin/python -c "import zmqtt"   # ModuleNotFoundError on 0.0.5
```
</details>
