### PR TITLE
fix: strip broker shared/decorator prefixes via a configurable allowlist

### DIFF
--- a/src/zmqtt/_internal/protocol.py
+++ b/src/zmqtt/_internal/protocol.py
@@ -43,12 +43,34 @@ from zmqtt.errors import (
 log = logging.getLogger(__name__)
 
 
-def _shared_filter_to_actual(filter_: str) -> str:
-    """Strip the $share/<group>/ prefix from a shared subscription filter."""
+# Group-less decorator prefixes the broker strips before delivery (unlike $SYS,
+# which it delivers on as-is). Extend via MQTTClient(stripped_prefixes=...).
+_DEFAULT_STRIPPED_PREFIXES: Final = ("$queue", "$exclusive")
+
+
+def _shared_filter_to_actual(filter_: str, stripped_prefixes: tuple[str, ...]) -> str:
+    """Return the filter the broker matches incoming PUBLISH topics against.
+
+    A shared/decorator subscription is sent with a prefix the broker strips before
+    delivery, so matching must run against the filter *without* it:
+
+    - ``$share/<group>/<filter>`` — MQTT 5 shared subscription (the only form that
+      carries a group), handled here directly;
+    - each entry in ``stripped_prefixes`` — a group-less decorator such as
+      ``$queue/<filter>`` or ``$exclusive/<filter>``.
+
+    Anything else — a plain filter, or a real namespace like ``$SYS/#`` the broker
+    delivers on unchanged — is returned untouched. The allowlist fails safe: an
+    unrecognised prefix is left as-is, so a mismatch surfaces as a loud
+    "No subscriber" rather than a silent mis-route.
+    """
     if filter_.startswith("$share/"):
         parts = filter_.split("/", 2)
         if len(parts) == 3:
             return parts[2]
+    for prefix in stripped_prefixes:
+        if filter_.startswith(f"{prefix}/"):
+            return filter_.split("/", 1)[1]
     return filter_
 
 
@@ -104,6 +126,7 @@ class MQTTProtocol:
         ping_timeout: float = 10.0,
         connect_timeout: float = 30.0,
         version: Literal["3.1.1", "5.0"] = "3.1.1",
+        stripped_prefixes: tuple[str, ...] = _DEFAULT_STRIPPED_PREFIXES,
     ) -> None:
         self._transport = transport
         self._state = state
@@ -111,6 +134,7 @@ class MQTTProtocol:
         self._ping_timeout = ping_timeout
         self._connect_timeout = connect_timeout
         self._version: Final = version
+        self._stripped_prefixes = stripped_prefixes
         self._buf = PacketBuffer(version=version)
         self._ping_waiters: list[asyncio.Future[None]] = []
         self._disconnecting = False
@@ -261,7 +285,7 @@ class MQTTProtocol:
                 new_entries[f] = SubscriptionEntry(
                     queue=asyncio.Queue(),
                     auto_ack=auto_ack,
-                    actual_filter=_shared_filter_to_actual(f),
+                    actual_filter=_shared_filter_to_actual(f, self._stripped_prefixes),
                 )
         self._state.subscriptions.update(new_entries)
         future: asyncio.Future[SubAck] = loop.create_future()

--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -22,7 +22,7 @@ from zmqtt._internal.packets.properties import (
 )
 from zmqtt._internal.packets.publish import Publish
 from zmqtt._internal.packets.subscribe import SubscriptionRequest
-from zmqtt._internal.protocol import MQTTProtocol
+from zmqtt._internal.protocol import _DEFAULT_STRIPPED_PREFIXES, MQTTProtocol
 from zmqtt._internal.state import SessionState
 from zmqtt._internal.transport.base import Transport
 from zmqtt._internal.transport.tcp import open_tcp
@@ -304,6 +304,7 @@ class MQTTClient:
         transport_factory: TransportFactory | None = None,
         version: Literal["3.1.1", "5.0"] = "3.1.1",
         session_expiry_interval: int = 0,
+        stripped_prefixes: tuple[str, ...] = _DEFAULT_STRIPPED_PREFIXES,
     ) -> None:
         """Create an MQTT client.
 
@@ -339,6 +340,12 @@ class MQTTClient:
                 ``"5.0"``.
             session_expiry_interval: MQTT 5.0 session expiry interval in seconds.
                 ``0`` means the session expires on disconnect.
+            stripped_prefixes: Group-less subscription prefixes the broker strips
+                before delivery — matched against incoming PUBLISH topics with the
+                prefix removed. Defaults to ``("$queue", "$exclusive")``; add a
+                broker-specific decorator here instead of patching the library.
+                ``$share/<group>/`` is always handled; real namespaces the broker
+                delivers on unchanged (e.g. ``$SYS``) must not be listed.
         """
         if not mqtt_connect_timeout > 0:
             msg = "mqtt_connect_timeout must be positive"
@@ -356,6 +363,7 @@ class MQTTClient:
         self._transport_factory: TransportFactory = transport_factory or _default_transport_factory
         self._version: Final = version
         self._session_expiry_interval = session_expiry_interval
+        self._stripped_prefixes = stripped_prefixes
         self._protocol: MQTTProtocol | None = None
         self._subscriptions: list[Subscription] = []
         self._run_task: asyncio.Task[None] | None = None
@@ -620,6 +628,7 @@ class MQTTClient:
             keepalive=self._keepalive,
             connect_timeout=self._mqtt_connect_timeout,
             version=self._version,
+            stripped_prefixes=self._stripped_prefixes,
         )
         connect_props = None
         if self._version == "5.0":

--- a/tests/test_brokers/test_emqx.py
+++ b/tests/test_brokers/test_emqx.py
@@ -1,5 +1,7 @@
+import asyncio
+
 from tests.test_brokers._base import BrokerTestBase
-from zmqtt import Subscription
+from zmqtt import MQTTClient, QoS, Subscription
 
 
 class BaseTestEMQX(BrokerTestBase):
@@ -12,6 +14,27 @@ class BaseTestEMQX(BrokerTestBase):
         for _ in range(n_duplicates):
             await sub.get_message()
         assert sub._queue.empty()
+
+    async def test_queue_prefixed_subscription_receives(self, topic: str) -> None:
+        """A ``$queue/<filter>`` subscription (EMQX's group-less shared subscription) must
+        receive messages published to the real topic.
+
+        The broker strips the ``$queue/`` prefix and delivers on the bare topic, so the
+        client must strip it too to match — otherwise every message is dropped as having
+        no subscriber. This is how EMQX Message Queues are consumed.
+        """
+        bare = topic.lstrip("/")
+        async with (
+            MQTTClient(self.host, self.port, version=self.version) as client,
+            client.subscribe(f"$queue/{bare}", qos=QoS.AT_LEAST_ONCE) as sub,
+            MQTTClient(self.host, self.port, version=self.version) as publisher,
+        ):
+            for i in range(3):
+                await publisher.publish(bare, f"s{i}".encode(), qos=QoS.AT_LEAST_ONCE)
+
+            received = [await asyncio.wait_for(sub.get_message(), timeout=5.0) for _ in range(3)]
+
+        assert {m.payload for m in received} == {b"s0", b"s1", b"s2"}
 
 
 class TestEMQXV311(BaseTestEMQX):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -14,7 +14,12 @@ import pytest
 from zmqtt._internal.packets.codec import encode
 from zmqtt._internal.packets.connect import ConnAck, Connect
 from zmqtt._internal.packets.publish import PubAck, Publish
-from zmqtt._internal.protocol import MQTTProtocol
+from zmqtt._internal.packets.subscribe import SubAck, SubscriptionRequest
+from zmqtt._internal.protocol import (
+    _DEFAULT_STRIPPED_PREFIXES,
+    MQTTProtocol,
+    _shared_filter_to_actual,
+)
 from zmqtt._internal.state import SessionState, SubscriptionEntry
 from zmqtt._internal.types.message import Message
 from zmqtt._internal.types.qos import QoS
@@ -54,6 +59,7 @@ class FakeTransport:
 def make_protocol(
     keepalive: int = 60,
     ping_timeout: float = 5.0,
+    stripped_prefixes: tuple[str, ...] = _DEFAULT_STRIPPED_PREFIXES,
 ) -> tuple[MQTTProtocol, FakeTransport]:
     transport = FakeTransport()
     state = SessionState()
@@ -62,6 +68,7 @@ def make_protocol(
         state,
         keepalive=keepalive,
         ping_timeout=ping_timeout,
+        stripped_prefixes=stripped_prefixes,
     )
     return protocol, transport
 
@@ -141,6 +148,76 @@ async def test_deliver_no_match_logs_warning(caplog: pytest.LogCaptureFixture) -
         )
 
     assert "unknown/topic" in caplog.text
+
+
+async def test_stripped_prefix_filter_receives_messages() -> None:
+    """A group-less decorator ($queue, $exclusive, ...) is stripped for matching.
+
+    The broker delivers on the real topic, so without stripping the prefix every
+    message is dropped with "No subscriber".
+    """
+    protocol, _ = make_protocol()
+    entry = SubscriptionEntry(
+        queue=asyncio.Queue(),
+        actual_filter=_shared_filter_to_actual("$queue/sensors/+/state", _DEFAULT_STRIPPED_PREFIXES),
+    )
+    protocol._state.subscriptions["$queue/sensors/+/state"] = entry
+
+    await protocol._deliver(
+        Publish(
+            topic="sensors/dev-1/state",
+            payload=b"x",
+            qos=QoS.AT_MOST_ONCE,
+            retain=False,
+            dup=False,
+        ),
+        ack_callback=None,
+    )
+
+    assert entry.queue.qsize() == 1
+
+
+def test_shared_prefixes_are_stripped_for_matching() -> None:
+    strip = _DEFAULT_STRIPPED_PREFIXES
+    # $share carries a group; the group-less decorators do not.
+    assert _shared_filter_to_actual("$share/group/a/+/b", strip) == "a/+/b"
+    assert _shared_filter_to_actual("$queue/a/+/b", strip) == "a/+/b"
+    assert _shared_filter_to_actual("$exclusive/a/+/b", strip) == "a/+/b"
+    assert _shared_filter_to_actual("a/+/b", strip) == "a/+/b"
+    # A malformed $share prefix is left as-is rather than guessed at.
+    assert _shared_filter_to_actual("$share/only-group", strip) == "$share/only-group"
+
+
+def test_unknown_prefixes_are_not_stripped() -> None:
+    """The allowlist fails safe: a real namespace or an unconfigured decorator is
+    left untouched (a loud "No subscriber" beats a silent mis-route), until the
+    broker's decorator is added to the allowlist.
+    """
+    strip = _DEFAULT_STRIPPED_PREFIXES
+    assert _shared_filter_to_actual("$SYS/#", strip) == "$SYS/#"
+    assert _shared_filter_to_actual("$q/a/b", strip) == "$q/a/b"
+    assert _shared_filter_to_actual("$q/a/b", ("$q",)) == "a/b"
+
+
+async def test_configured_prefix_reaches_subscribe() -> None:
+    """A prefix added via stripped_prefixes is applied to the stored actual_filter."""
+    protocol, transport = make_protocol(stripped_prefixes=("$q",))
+
+    async def subscribe() -> None:
+        await protocol.subscribe(
+            [SubscriptionRequest(topic_filter="$q/sensors/+/state", qos=QoS.AT_MOST_ONCE)],
+        )
+
+    task = asyncio.create_task(subscribe())
+    await asyncio.sleep(0)
+    transport.feed(encode(SubAck(packet_id=1, return_codes=(0x00,)), version="3.1.1"))
+    read = asyncio.create_task(protocol._read_loop())
+    await task
+    read.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await read
+
+    assert protocol._state.subscriptions["$q/sensors/+/state"].actual_filter == "sensors/+/state"
 
 
 async def test_inbound_qos2_manual_ack_duplicate_ignored() -> None:


### PR DESCRIPTION
A subscription registered under a prefixed filter (`$share/<group>/…`, `$queue/…`, `$exclusive/…`) never matched incoming PUBLISHes: the broker strips the prefix and delivers on the underlying real topic, but the client matched that real topic against the still-prefixed stored filter, so every message was dropped with a `No subscriber` warning.

## Why it matters

`$queue/<filter>` is how EMQX Message Queues are consumed (durable, at-least-once — the natural fit for traffic that must survive a redeploy, e.g. payments), and `$exclusive/`/`$share/` are the standard shared-subscription forms. All of them were silently broken.

## Symptom

```
log: zmqtt._internal.protocol: No subscriber for topic 'demo/dev-1/sale'   (× 3)
received: 0 of 3 published
```

## Cause

`_shared_filter_to_actual` (`_internal/protocol.py`) stripped only `$share/<group>/`. Any other decorator prefix stayed on the stored filter, so `_topic_matches` never matched the real delivery topic.

## What this PR does

`_shared_filter_to_actual` now returns the filter the broker actually matches against:

- `$share/<group>/<filter>` — stripped directly; it is the only group-carrying form in MQTT (spec);
- a **configurable allowlist** of group-less decorators — default `("$queue", "$exclusive")` — stripped of their one leading segment. Extend it per client with `MQTTClient(stripped_prefixes=(...))`, so a broker-specific decorator is one config line rather than a library edit.

### Why an allowlist, not "strip any `$…`"

`$SYS/#` is the counterexample: `$share`/`$queue`/`$exclusive` are routing *decorators* the broker removes before delivery, whereas `$SYS` is a real *namespace* the broker delivers on unchanged. The two are indistinguishable by string shape, so a blanket "strip every `$word/`" rule would silently corrupt `$SYS` subscriptions. The allowlist **fails safe**: an unrecognised prefix is left untouched, so a mismatch surfaces as a loud `No subscriber` rather than a silent mis-route.

## Verification

- Tests: `$share`/`$queue`/`$exclusive` stripped; plain filters and `$SYS/#` left untouched; a custom prefix stripped only once added to `stripped_prefixes`; end-to-end through `subscribe()`.
- Full suite, `ruff check` (select=ALL), `mypy --strict` green. The MRE below receives 3/3 on the fixed branch.

<details><summary>Reproduction (MRE)</summary>

Setup: `docker run -d -p 1883:1883 emqx/emqx:latest`, `pip install zmqtt`.

```python
"""$queue/<filter> is the group-less shared-subscription form (equivalent to
$share/$queue/<filter>), supported by EMQX. The broker accepts the SUBSCRIBE and
delivers, but the incoming topic never matches the stored $queue/... filter, so
every message is dropped with a "No subscriber" warning."""

import asyncio
import contextlib
import logging
import os

from zmqtt import MQTTClient, QoS

HOST = os.environ.get("MQTT_HOST", "localhost")
PORT = int(os.environ.get("MQTT_PORT", "1883"))

logging.basicConfig(level=logging.WARNING, format="log: %(name)s: %(message)s")


async def main() -> None:
    async with MQTTClient(HOST, PORT, client_id="queue-demo", version="5.0") as client:
        async with client.subscribe("$queue/demo/+/sale", qos=QoS.AT_LEAST_ONCE) as subscription:
            async with MQTTClient(HOST, PORT, client_id="queue-pub", version="5.0") as publisher:
                for i in range(3):
                    await publisher.publish("demo/dev-1/sale", f"sale-{i}".encode(), qos=QoS.AT_LEAST_ONCE)

            got: list[bytes] = []

            async def read() -> None:
                async for message in subscription:
                    got.append(message.payload)

            with contextlib.suppress(asyncio.TimeoutError):
                await asyncio.wait_for(read(), 2.0)

    print(f"received: {len(got)} of 3 published", flush=True)


asyncio.run(main())
```
</details>
