### PR TITLE
fix: raise on SUBACK failure codes instead of ignoring them

### DIFF
--- a/src/zmqtt/__init__.py
+++ b/src/zmqtt/__init__.py
@@ -16,6 +16,7 @@ from zmqtt.errors import (
     MQTTError,
     MQTTInvalidTopicError,
     MQTTProtocolError,
+    MQTTSubscribeError,
     MQTTTimeoutError,
 )
 
@@ -30,6 +31,7 @@ __all__ = (
     "MQTTError",
     "MQTTInvalidTopicError",
     "MQTTProtocolError",
+    "MQTTSubscribeError",
     "MQTTTimeoutError",
     "Message",
     "PublishProperties",

--- a/src/zmqtt/_internal/protocol.py
+++ b/src/zmqtt/_internal/protocol.py
@@ -37,6 +37,7 @@ from zmqtt.errors import (
     MQTTConnectError,
     MQTTDisconnectedError,
     MQTTProtocolError,
+    MQTTSubscribeError,
     MQTTTimeoutError,
 )
 
@@ -105,6 +106,20 @@ def _segment_rank(seg: str) -> int:
 def _filter_specificity(actual_filter: str) -> tuple[int, ...]:
     """Return a sort key for a filter (shared prefix already stripped); lexicographically smaller == more specific."""
     return tuple(_segment_rank(s) for s in actual_filter.split("/"))
+
+
+def _raise_on_rejected_filters(filters: list[SubscriptionRequest], suback: SubAck) -> None:
+    """Surface SUBACK failure codes (>= 0x80) instead of ignoring them.
+
+    A rejected filter — most commonly an authorization denial — otherwise looks
+    exactly like a successful subscription and silently never receives anything.
+    Return codes map to filters by position (MQTT 3.1.1 §3.9.3, 5.0 §3.9.2.1).
+    """
+    # strict=False: a non-conforming broker answering with a short code list
+    # should not turn into a ValueError here.
+    failures = {req.topic_filter: code for req, code in zip(filters, suback.return_codes, strict=False) if code >= 0x80}
+    if failures:
+        raise MQTTSubscribeError(failures)
 
 
 class MQTTProtocol:
@@ -318,6 +333,7 @@ class MQTTProtocol:
         log.debug("Sent SUBSCRIBE", extra={"packet_id": pid})
         try:
             suback = await future
+            _raise_on_rejected_filters(filters, suback)
         except Exception:
             for f in new_entries:
                 self._state.subscriptions.pop(f, None)

--- a/src/zmqtt/errors.py
+++ b/src/zmqtt/errors.py
@@ -22,5 +22,18 @@ class MQTTTimeoutError(MQTTError):
     """An MQTT operation did not complete within the allotted time."""
 
 
+class MQTTSubscribeError(MQTTError):
+    """The broker rejected one or more filters in a SUBSCRIBE (SUBACK >= 0x80).
+
+    Most commonly an authorization denial: without this error the subscription
+    looks successful and silently never receives anything.
+    """
+
+    def __init__(self, failures: dict[str, int]) -> None:
+        self.failures = failures
+        rendered = ", ".join(f"{f!r} (0x{code:02X})" for f, code in failures.items())
+        super().__init__(f"Broker rejected subscription: {rendered}")
+
+
 class MQTTInvalidTopicError(MQTTError):
     """Topic string or topic filter failed MQTT validation."""

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -19,12 +19,19 @@ from zmqtt._internal.packets.subscribe import SubAck, SubscriptionRequest
 from zmqtt._internal.protocol import (
     _DEFAULT_STRIPPED_PREFIXES,
     MQTTProtocol,
+    _raise_on_rejected_filters,
     _shared_filter_to_actual,
 )
 from zmqtt._internal.state import SessionState, SubscriptionEntry
 from zmqtt._internal.types.message import Message
 from zmqtt._internal.types.qos import QoS
-from zmqtt.errors import MQTTConnectError, MQTTDisconnectedError, MQTTProtocolError, MQTTTimeoutError
+from zmqtt.errors import (
+    MQTTConnectError,
+    MQTTDisconnectedError,
+    MQTTProtocolError,
+    MQTTSubscribeError,
+    MQTTTimeoutError,
+)
 
 
 class FakeTransport:
@@ -253,6 +260,27 @@ async def test_dead_protocol_refuses_new_operations() -> None:
         await protocol.subscribe(
             [SubscriptionRequest(topic_filter="a/b", qos=QoS.AT_MOST_ONCE)],
         )
+
+
+def test_suback_failure_codes_raise() -> None:
+    """A rejected filter (SUBACK >= 0x80, e.g. an ACL denial) must not look successful."""
+    filters = [
+        SubscriptionRequest(topic_filter="allowed/topic", qos=QoS.AT_LEAST_ONCE),
+        SubscriptionRequest(topic_filter="$SYS/#", qos=QoS.AT_LEAST_ONCE),
+    ]
+    suback = SubAck(packet_id=1, return_codes=(0x01, 0x80))
+
+    with pytest.raises(MQTTSubscribeError) as exc_info:
+        _raise_on_rejected_filters(filters, suback)
+
+    assert exc_info.value.failures == {"$SYS/#": 0x80}
+
+
+def test_suback_granted_codes_pass() -> None:
+    filters = [SubscriptionRequest(topic_filter="a/b", qos=QoS.EXACTLY_ONCE)]
+    suback = SubAck(packet_id=1, return_codes=(0x02,))
+
+    _raise_on_rejected_filters(filters, suback)  # no raise
 
 
 async def test_inbound_qos2_manual_ack_duplicate_ignored() -> None:


### PR DESCRIPTION
A filter the broker rejects returned normally from `subscribe()` and then silently received nothing, forever. On any broker with topic ACLs this is close to undiagnosable in production: the connection is healthy, the code is right, the messages are simply absent.

## Why it matters

Any production broker where services and devices have scoped permissions. A subscribe to a filter you are not allowed to read (a typo, a stale ACL rule, a not-yet-granted topic) is answered with SUBACK `0x80` (v5 `0x87 Not authorized`) — and today that looks identical to success. No custom ACL is needed to hit it: EMQX's **default** authorization denies `$SYS/#` and the bare `#` to ordinary clients.

## Symptom

The MRE asks the broker directly (raw MQTT 3.1.1) and then subscribes through zmqtt:

```
broker's actual SUBACK for '$SYS/#': 0x80 (FAILURE)
zmqtt.subscribe(): returned normally — no error raised
messages received afterwards: 0 (and never will be any)
```

## Cause

`_handle_suback` (`_internal/protocol.py`) resolves the pending future with the SubAck, and the caller discards it (`_, queues = await protocol.subscribe(...)`). `SubAck.return_codes` — which map to filters by position (3.1.1 §3.9.3, 5.0 §3.9.2.1) — are never inspected anywhere.

## What this PR does

The return codes are checked when the SUBACK arrives; any code `>= 0x80` raises `MQTTSubscribeError` naming the rejected filters and their codes. The optimistically-registered queues are rolled back by the existing cleanup path in `subscribe()`.

Semantics note: any rejected filter fails the whole `subscribe()` call (all newly-registered entries are rolled back) — atomic failure rather than silent partial success. This is strictly better than today's ignore; flagging it in case you would prefer per-filter partial success instead.

## Verification

Tests: a mixed SUBACK (`0x01`, `0x80`) raises, naming the rejected filter; an all-granted SUBACK passes. Full suite, `ruff check` (select=ALL), `mypy --strict` green. On this branch the MRE ends with `raised MQTTSubscribeError`.

<details><summary>Reproduction (MRE)</summary>

Setup: `docker run -d -p 1883:1883 emqx/emqx:latest`, `pip install zmqtt`.

```python
"""EMQX's default authorization denies subscribing to $SYS/# for ordinary clients,
answering SUBACK with return code 0x80. This proves the denial with a raw MQTT
3.1.1 exchange, then shows that zmqtt.subscribe() on the same filter returns as if
everything were fine."""

import asyncio
import contextlib
import os
import socket
import struct

from zmqtt import MQTTClient, QoS

HOST = os.environ.get("MQTT_HOST", "localhost")
PORT = int(os.environ.get("MQTT_PORT", "1883"))
DENIED_FILTER = "$SYS/#"


def raw_suback_code(topic_filter: str) -> int:
    """Ask the broker directly (raw MQTT 3.1.1) what it answers to this SUBSCRIBE."""

    def encode_str(value: bytes) -> bytes:
        return struct.pack("!H", len(value)) + value

    sock = socket.create_connection((HOST, PORT), timeout=5)
    try:
        connect_body = (
            encode_str(b"MQTT") + bytes([4, 0x02]) + struct.pack("!H", 60)
            + encode_str(b"raw-suback-probe")
        )
        sock.sendall(bytes([0x10, len(connect_body)]) + connect_body)
        assert sock.recv(4)[3] == 0, "CONNACK refused"

        sub_body = struct.pack("!H", 1) + encode_str(topic_filter.encode()) + bytes([1])
        sock.sendall(bytes([0x82, len(sub_body)]) + sub_body)
        return sock.recv(8)[4]
    finally:
        sock.close()


async def main() -> None:
    code = raw_suback_code(DENIED_FILTER)
    print(f"broker's actual SUBACK for {DENIED_FILTER!r}: 0x{code:02X} "
          f"({'FAILURE' if code >= 0x80 else 'granted'})", flush=True)

    async with MQTTClient(HOST, PORT, client_id="suback-demo", version="5.0") as client:
        try:
            async with client.subscribe(DENIED_FILTER, qos=QoS.AT_LEAST_ONCE) as subscription:
                print("zmqtt.subscribe(): returned normally — no error raised", flush=True)
                got = []

                async def read() -> None:
                    async for message in subscription:
                        got.append(message)

                with contextlib.suppress(asyncio.TimeoutError):
                    await asyncio.wait_for(read(), 3.0)
                print(f"messages received afterwards: {len(got)} (and never will be any)", flush=True)
        except Exception as error:  # noqa: BLE001
            print(f"zmqtt.subscribe(): raised {type(error).__name__} (expected behaviour)", flush=True)


asyncio.run(main())
```
</details>
