### PR TITLE
fix: bound the protocol-level delivery queue

### DIFF
--- a/src/zmqtt/_internal/protocol.py
+++ b/src/zmqtt/_internal/protocol.py
@@ -243,12 +243,18 @@ class MQTTProtocol:
         filters: list[SubscriptionRequest],
         *,
         auto_ack: bool = True,
+        queue_maxsize: int = 0,
     ) -> tuple[SubAck, dict[str, asyncio.Queue[Message]]]:
         """Send SUBSCRIBE and return (SubAck, {filter: queue}) after broker ACK.
 
         Queues are registered before SUBSCRIBE is sent so no messages are lost.
         Duplicate filters (already subscribed) are logged as warnings and skipped;
         they are still included in the SUBSCRIBE packet sent to the broker.
+
+        ``queue_maxsize`` bounds the per-filter delivery queue. When it is full,
+        ``_deliver`` blocks, which stalls the read loop and ultimately pushes back
+        on the broker through the TCP window — the flow-control chain the docs
+        describe. ``0`` keeps the queue unbounded.
         """
         loop = asyncio.get_running_loop()
         pid = self._state.packet_ids.acquire()
@@ -259,7 +265,7 @@ class MQTTProtocol:
                 log.warning("Filter %r already subscribed (ignored)", f)
             else:
                 new_entries[f] = SubscriptionEntry(
-                    queue=asyncio.Queue(),
+                    queue=asyncio.Queue(queue_maxsize),
                     auto_ack=auto_ack,
                     actual_filter=_shared_filter_to_actual(f),
                 )

--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -214,7 +214,11 @@ class Subscription:
             )
             for f in self._filters
         ]
-        _, queues = await protocol.subscribe(reqs, auto_ack=self._auto_ack)
+        _, queues = await protocol.subscribe(
+            reqs,
+            auto_ack=self._auto_ack,
+            queue_maxsize=self._queue.maxsize,
+        )
         self._registered_filters = list(queues.keys())
         for q in queues.values():
             task: asyncio.Task[None] = asyncio.create_task(self._relay_loop(q))
@@ -492,8 +496,10 @@ class MQTTClient:
             qos: Maximum QoS level requested from the broker.
             auto_ack: Automatically send PUBACK/PUBREC upon receipt. Set to
                 ``False`` to acknowledge manually via :meth:`Message.ack`.
-            receive_buffer_size: Maximum messages buffered in the internal queue.
-                Older messages are dropped when the queue is full.
+            receive_buffer_size: Maximum messages buffered per internal queue.
+                When the buffers are full the read loop stops pulling from the
+                socket, so a slow consumer pushes back on the broker through the
+                TCP window instead of growing memory.
             no_local: Do not receive messages published by this client (MQTT 5.0
                 only).
             retain_as_published: Preserve the retain flag on forwarded messages

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -14,7 +14,6 @@ import pytest
 from zmqtt._internal.packets.codec import encode
 from zmqtt._internal.packets.connect import ConnAck, Connect
 from zmqtt._internal.packets.publish import PubAck, Publish
-from zmqtt._internal.packets.subscribe import SubAck, SubscriptionRequest
 from zmqtt._internal.protocol import MQTTProtocol
 from zmqtt._internal.state import SessionState, SubscriptionEntry
 from zmqtt._internal.types.message import Message
@@ -142,35 +141,6 @@ async def test_deliver_no_match_logs_warning(caplog: pytest.LogCaptureFixture) -
         )
 
     assert "unknown/topic" in caplog.text
-
-
-async def test_protocol_queue_is_bounded() -> None:
-    """The per-filter delivery queue must honour queue_maxsize.
-
-    Unbounded, a slow consumer grows it without limit — no drop, no block, no
-    TCP backpressure, just memory (18 999 of 20 000 flood messages in practice).
-    """
-    protocol, transport = make_protocol()
-
-    async def subscribe() -> dict[str, asyncio.Queue[Message]]:
-        _, queues = await protocol.subscribe(
-            [SubscriptionRequest(topic_filter="flood/#", qos=QoS.AT_MOST_ONCE)],
-            queue_maxsize=5,
-        )
-        return queues
-
-    task = asyncio.create_task(subscribe())
-    await asyncio.sleep(0)
-    suback = encode(SubAck(packet_id=1, return_codes=(0x00,)), version="3.1.1")
-    transport.feed(suback)
-    read = asyncio.create_task(protocol._read_loop())
-    queues = await task
-    read.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await read
-
-    (queue,) = queues.values()
-    assert queue.maxsize == 5
 
 
 async def test_inbound_qos2_manual_ack_duplicate_ignored() -> None:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -14,6 +14,7 @@ import pytest
 from zmqtt._internal.packets.codec import encode
 from zmqtt._internal.packets.connect import ConnAck, Connect
 from zmqtt._internal.packets.publish import PubAck, Publish
+from zmqtt._internal.packets.subscribe import SubAck, SubscriptionRequest
 from zmqtt._internal.protocol import MQTTProtocol
 from zmqtt._internal.state import SessionState, SubscriptionEntry
 from zmqtt._internal.types.message import Message
@@ -141,6 +142,35 @@ async def test_deliver_no_match_logs_warning(caplog: pytest.LogCaptureFixture) -
         )
 
     assert "unknown/topic" in caplog.text
+
+
+async def test_protocol_queue_is_bounded() -> None:
+    """The per-filter delivery queue must honour queue_maxsize.
+
+    Unbounded, a slow consumer grows it without limit — no drop, no block, no
+    TCP backpressure, just memory (18 999 of 20 000 flood messages in practice).
+    """
+    protocol, transport = make_protocol()
+
+    async def subscribe() -> dict[str, asyncio.Queue[Message]]:
+        _, queues = await protocol.subscribe(
+            [SubscriptionRequest(topic_filter="flood/#", qos=QoS.AT_MOST_ONCE)],
+            queue_maxsize=5,
+        )
+        return queues
+
+    task = asyncio.create_task(subscribe())
+    await asyncio.sleep(0)
+    suback = encode(SubAck(packet_id=1, return_codes=(0x00,)), version="3.1.1")
+    transport.feed(suback)
+    read = asyncio.create_task(protocol._read_loop())
+    queues = await task
+    read.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await read
+
+    (queue,) = queues.values()
+    assert queue.maxsize == 5
 
 
 async def test_inbound_qos2_manual_ack_duplicate_ignored() -> None:


### PR DESCRIPTION
"Backpressure: bounded subscription queues" is a headline feature, but only `Subscription._queue` was actually bounded. The per-filter protocol queue it is fed from was created with no maxsize, and `_deliver` does `await entry.queue.put(msg)` — which therefore never blocks. A consumer slower than the wire grew it without limit: no drop, no block, no TCP backpressure, just memory until the OOM killer steps in.

## Why it matters

A burst while the consumer lags the wire — e.g. a fleet of devices reconnecting after a broker restart, each publishing state within seconds, while the consumer writes to a database. The documented flow-control never engages.

## Symptom

```
published: 20000
subscription queue: 1000 held (maxsize=1000 — bounded, as documented)
protocol queue:     18999 held (maxsize=0 — UNBOUNDED)
```

## Cause

Two queues on the inbound path: `Subscription._queue` is bounded (`receive_buffer_size`, default 1000); the per-filter protocol queue in `protocol.subscribe()` is `asyncio.Queue()` with no bound. When the subscription buffer fills, the relay task blocks and everything the broker keeps sending piles up in the unbounded protocol queue.

The docs describe behaviour the code does not have: the `subscribe()` docstring promises *"older messages are dropped when the queue is full"* (there is no drop path in `src/`), and `docs/advanced/backpressure.md` describes a 5-step chain whose step 2 ("the protocol's internal queue fills up") cannot happen.

## What this PR does

The protocol queue takes its bound from the subscription's `receive_buffer_size`. When both buffers fill, `await put()` blocks, the read loop stops pulling from the socket, and the broker is pushed back through the TCP window — exactly the chain `backpressure.md` promises. The `subscribe()` docstring is corrected to describe the blocking chain instead of the never-implemented drop-oldest.

## Verification

Test asserts the per-filter queue honours `queue_maxsize`. Full suite, `ruff check` (select=ALL), `mypy --strict` green. Same MRE on the fixed branch:

```
published: 20000
subscription queue: 1000 held (maxsize=1000)
protocol queue:     1000 held (maxsize=1000)
```

<details><summary>Reproduction (MRE)</summary>

Setup: `docker run -d -p 1883:1883 emqx/emqx:latest`, `pip install zmqtt`.

```python
"""The protocol-level queue is unbounded — a slow consumer grows the process
without limit, despite the docs promising bounded queues. Subscribe, deliberately
do not read, publish 20 000 messages, then inspect both queues."""

import asyncio
import os

from zmqtt import MQTTClient, QoS

HOST = os.environ.get("MQTT_HOST", "localhost")
PORT = int(os.environ.get("MQTT_PORT", "1883"))
FLOOD = 20_000


async def main() -> None:
    async with MQTTClient(HOST, PORT, client_id="flood-demo", version="5.0") as client:
        async with client.subscribe("demo/flood/#", qos=QoS.AT_MOST_ONCE) as subscription:
            async with MQTTClient(HOST, PORT, client_id="flood-pub", version="5.0") as publisher:
                for _ in range(FLOOD):
                    await publisher.publish("demo/flood/x", b"x" * 200, qos=QoS.AT_MOST_ONCE)

            await asyncio.sleep(3)  # consumer deliberately not reading

            subscription_queue = subscription._queue  # noqa: SLF001
            protocol_entries = client._protocol._state.subscriptions.values()  # noqa: SLF001

            print(f"published: {FLOOD}", flush=True)
            print(f"subscription queue: {subscription_queue.qsize()} held "
                  f"(maxsize={subscription_queue.maxsize})", flush=True)
            for entry in protocol_entries:
                print(f"protocol queue:     {entry.queue.qsize()} held "
                      f"(maxsize={entry.queue.maxsize})", flush=True)


asyncio.run(main())
```
</details>
