### PR TITLE
fix: treat broker-initiated DISCONNECT as a disconnection, and fail f…

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,3 +30,10 @@ services:
       - "1887:1883"
     security_opt:
       - no-new-privileges:true
+
+  emqx:
+    image: emqx/emqx@sha256:0ba29902a8e552f7152754860b4b61b49a7e16fa376035bcf10021e944b2c0a0 # 6.2.2
+    ports:
+      - 1888:1883
+    security_opt:
+      - no-new-privileges:true

--- a/src/zmqtt/_internal/protocol.py
+++ b/src/zmqtt/_internal/protocol.py
@@ -138,6 +138,7 @@ class MQTTProtocol:
         self._buf = PacketBuffer(version=version)
         self._ping_waiters: list[asyncio.Future[None]] = []
         self._disconnecting = False
+        self._dead = False
         self.started_event = asyncio.Event()
 
     async def connect(self, packet: Connect) -> ConnAck:
@@ -187,6 +188,7 @@ class MQTTProtocol:
             raise
         finally:
             self.started_event.clear()
+            self._dead = True
             self._cancel_pending()
 
     async def disconnect(self) -> None:
@@ -217,10 +219,23 @@ class MQTTProtocol:
                 ping_f.set_exception(exc)
         self._ping_waiters.clear()
 
+    def _ensure_alive(self) -> None:
+        """Refuse new operations once the run loop has exited.
+
+        _cancel_pending() fails every future that existed when the loop died, but
+        an operation started afterwards would create a fresh future that nothing
+        will ever resolve — the caller would hang forever (a dead client used to
+        hang even in __aexit__, inside unsubscribe()).
+        """
+        if self._dead:
+            msg = "Connection lost"
+            raise MQTTDisconnectedError(msg)
+
     async def publish(self, packet: Publish) -> PubAck | PubComp | None:
         """
         Publish a message. Returns PubAck (QoS 1), PubComp (QoS 2), or None (QoS 0).
         """
+        self._ensure_alive()
         match packet.qos:
             case QoS.AT_MOST_ONCE:
                 await self._send(self._encode(packet))
@@ -280,6 +295,7 @@ class MQTTProtocol:
         on the broker through the TCP window — the flow-control chain the docs
         describe. ``0`` keeps the queue unbounded.
         """
+        self._ensure_alive()
         loop = asyncio.get_running_loop()
         pid = self._state.packet_ids.acquire()
         new_entries: dict[str, SubscriptionEntry] = {}
@@ -313,6 +329,7 @@ class MQTTProtocol:
 
     async def unsubscribe(self, filters: list[str]) -> UnsubAck:
         """Send UNSUBSCRIBE, remove queues from state, return UnsubAck."""
+        self._ensure_alive()
         pid = self._state.packet_ids.acquire()
         loop = asyncio.get_running_loop()
         future: asyncio.Future[UnsubAck] = loop.create_future()
@@ -395,9 +412,12 @@ class MQTTProtocol:
                 await self._handle_unsuback(packet)
             case PingResp():
                 self._handle_pingresp()
-            case Disconnect():
-                msg = "Broker sent DISCONNECT unexpectedly"
-                raise MQTTProtocolError(msg)
+            case Disconnect(reason_code=reason_code):
+                # A broker-initiated DISCONNECT (session takeover, keepalive timeout,
+                # admin kick) is a disconnection, not a protocol violation — raise it
+                # as MQTTDisconnectedError so it takes the reconnect path.
+                msg = f"Broker sent DISCONNECT (reason code 0x{reason_code:02X})"
+                raise MQTTDisconnectedError(msg)
             case Auth():
                 if self._version != "5.0":
                     msg = "Received AUTH packet in MQTT 3.1.1 session"

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -13,6 +13,7 @@ import pytest
 
 from zmqtt._internal.packets.codec import encode
 from zmqtt._internal.packets.connect import ConnAck, Connect
+from zmqtt._internal.packets.disconnect import Disconnect
 from zmqtt._internal.packets.publish import PubAck, Publish
 from zmqtt._internal.packets.subscribe import SubAck, SubscriptionRequest
 from zmqtt._internal.protocol import (
@@ -23,7 +24,7 @@ from zmqtt._internal.protocol import (
 from zmqtt._internal.state import SessionState, SubscriptionEntry
 from zmqtt._internal.types.message import Message
 from zmqtt._internal.types.qos import QoS
-from zmqtt.errors import MQTTConnectError, MQTTProtocolError, MQTTTimeoutError
+from zmqtt.errors import MQTTConnectError, MQTTDisconnectedError, MQTTProtocolError, MQTTTimeoutError
 
 
 class FakeTransport:
@@ -218,6 +219,40 @@ async def test_configured_prefix_reaches_subscribe() -> None:
         await read
 
     assert protocol._state.subscriptions["$q/sensors/+/state"].actual_filter == "sensors/+/state"
+
+
+async def test_broker_disconnect_is_a_disconnection() -> None:
+    """A broker-initiated DISCONNECT must take the reconnect path.
+
+    Brokers send it on session takeover (same client id — every rolling deploy),
+    keepalive timeout, admin kick and rate limiting. Raised as a protocol error it
+    killed the run task silently: iterators hung forever and nothing reconnected.
+    """
+    protocol, transport = make_protocol()
+
+    transport.feed(encode(Disconnect(reason_code=0x8E), version="3.1.1"))
+
+    with pytest.raises(MQTTDisconnectedError):
+        await asyncio.wait_for(protocol._read_loop(), timeout=1)
+
+
+async def test_dead_protocol_refuses_new_operations() -> None:
+    """Operations after the run loop died must fail fast, not hang.
+
+    _cancel_pending() fails futures that already exist; an unsubscribe() issued
+    afterwards (e.g. Subscription.__aexit__ on a dead client) used to create a
+    fresh future that nothing would ever resolve.
+    """
+    protocol, _ = make_protocol()
+    protocol._dead = True
+
+    with pytest.raises(MQTTDisconnectedError):
+        await protocol.unsubscribe(["a/b"])
+
+    with pytest.raises(MQTTDisconnectedError):
+        await protocol.subscribe(
+            [SubscriptionRequest(topic_filter="a/b", qos=QoS.AT_MOST_ONCE)],
+        )
 
 
 async def test_inbound_qos2_manual_ack_duplicate_ignored() -> None:


### PR DESCRIPTION
Brokers send DISCONNECT in normal operation — session takeover (a second client with the same client id, i.e. **every rolling deploy**), keepalive timeout, admin kick, rate limiting. zmqtt raised it as `MQTTProtocolError`, which `_run_loop` does not catch, so the run task died with an error nobody awaits: subscription iterators hung forever, the existing auto-reconnect machinery never engaged, and the application had no way to notice. A consumer stops receiving while reporting itself healthy.

## Symptom

The MRE triggers the takeover with a second client on the same client id (pure MQTT, no broker CLI):

```
victim connected and subscribed
takeover done, broker has sent DISCONNECT to the victim
iterator: HANGS — no message, no error after 5s
internal run task died with: MQTTProtocolError('Broker sent DISCONNECT unexpectedly')
teardown: HANGS — __aexit__ did not finish in 5s
```

## Cause

1. `_read_loop` dispatch: `case Disconnect(): raise MQTTProtocolError(...)`. But `client._run_loop` only catches `(MQTTDisconnectedError, MQTTTimeoutError)`, so reconnect never engages and the error dies unobserved in the run task.
2. Once the run loop has exited, `_cancel_pending()` fails the futures that *already exist* — but an operation issued afterwards creates a fresh future nothing will ever resolve. That is why even `__aexit__` hangs: it calls `unsubscribe()`, awaiting an UNSUBACK that never arrives.

## What this PR does

1. Classifies a broker DISCONNECT as a *disconnection*, not a protocol violation — `MQTTDisconnectedError` (with the v5 reason code in the message) — which routes it into the reconnect path that already exists (reconnect with backoff, resubscribe, keep consuming). No new reconnect logic.
2. The protocol refuses new operations once the run loop has exited, failing fast with `MQTTDisconnectedError` instead of parking a future forever.

Two closely-related fixes ride together here because both concern behaviour after the run loop exits; happy to split them if you would prefer.

## Verification

Tests: a broker DISCONNECT raises `MQTTDisconnectedError` from the read loop; a dead protocol rejects `subscribe()`/`unsubscribe()` instead of hanging. Full suite, `ruff check` (select=ALL), `mypy --strict` green. On the fixed branch the takeover ends with the victim reconnected and receiving again (`VERDICT: RECONNECTED`).

<details><summary>Reproduction (MRE)</summary>

Setup: `docker run -d -p 1883:1883 emqx/emqx:latest` (any broker works), `pip install zmqtt`.

```python
"""A broker-initiated DISCONNECT kills the client silently. Triggered by a session
takeover: a second client connects with the same client id, so the broker
disconnects the first one (MQTT 5 reason 0x8E) — what happens on every rolling
deploy. Expected: the first client reconnects, or its iterator raises. Actual: the
iterator hangs, the error sits unobserved in an internal task, and __aexit__ hangs."""

import asyncio
import logging
import os

from zmqtt import MQTTClient, QoS

HOST = os.environ.get("MQTT_HOST", "localhost")
PORT = int(os.environ.get("MQTT_PORT", "1883"))
logging.basicConfig(level=logging.WARNING, format="log: %(name)s %(message)s")


async def main() -> None:
    victim = MQTTClient(HOST, PORT, client_id="takeover-demo", version="5.0")
    await victim.__aenter__()
    subscription_ctx = victim.subscribe("demo/topic", qos=QoS.AT_LEAST_ONCE)
    subscription = await subscription_ctx.__aenter__()
    print("victim connected and subscribed", flush=True)

    # Session takeover: same client id -> broker sends DISCONNECT to the victim.
    async with MQTTClient(HOST, PORT, client_id="takeover-demo", version="5.0"):
        await asyncio.sleep(1)
    print("takeover done, broker has sent DISCONNECT to the victim", flush=True)
    await asyncio.sleep(2)

    try:  # 1. The application-facing iterator: hangs, no error.
        async def read_one() -> None:
            async for _ in subscription:
                return
        await asyncio.wait_for(read_one(), timeout=5)
        print("iterator: returned (unexpected)", flush=True)
    except asyncio.TimeoutError:
        print("iterator: HANGS — no message, no error after 5s", flush=True)

    run_task = victim._run_task  # 2. Where the error actually went.
    if run_task.done() and run_task.exception():
        print(f"internal run task died with: {run_task.exception()!r}", flush=True)

    try:  # 3. Even teardown of the dead client hangs.
        await asyncio.wait_for(subscription_ctx.__aexit__(None, None, None), timeout=5)
        await asyncio.wait_for(victim.__aexit__(None, None, None), timeout=5)
        print("teardown: completed (unexpected)", flush=True)
    except asyncio.TimeoutError:
        print("teardown: HANGS — __aexit__ did not finish in 5s", flush=True)


asyncio.run(main())
```
</details>
