### PR TITLE
test: add EMQX to the broker test matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,6 +48,13 @@ jobs:
         options: >-
           --security-opt no-new-privileges:true
 
+      emqx:
+        image: emqx/emqx@sha256:0ba29902a8e552f7152754860b4b61b49a7e16fa376035bcf10021e944b2c0a0  # 6.2.2
+        ports:
+          - 1888:1883
+        options: >-
+          --security-opt no-new-privileges:true
+
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
@@ -74,7 +81,7 @@ jobs:
           sleep 15
 
           # Test connections to brokers
-          for port in 1883 1884 1886 1887; do
+          for port in 1883 1884 1886 1887 1888; do
             nc -zv localhost $port || echo "Port $port not responding"
           done
 
@@ -114,7 +121,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --group dev
-      - run: uv run pytest -vv --cov=src/zmqtt --cov-report=xml --ignore=tests/test_brokers/test_artemis.py --ignore=tests/test_brokers/test_hivemq.py --ignore=tests/test_brokers/test_nanomq.py
+      - run: uv run pytest -vv --cov=src/zmqtt --cov-report=xml --ignore=tests/test_brokers/test_artemis.py --ignore=tests/test_brokers/test_hivemq.py --ignore=tests/test_brokers/test_nanomq.py --ignore=tests/test_brokers/test_emqx.py
       - uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad  # v5
         with:
           files: coverage.xml
@@ -144,7 +151,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --group dev
-      - run: uv run pytest -vv --cov=src/zmqtt --cov-report=xml --ignore=tests/test_brokers/test_artemis.py --ignore=tests/test_brokers/test_hivemq.py --ignore=tests/test_brokers/test_nanomq.py
+      - run: uv run pytest -vv --cov=src/zmqtt --cov-report=xml --ignore=tests/test_brokers/test_artemis.py --ignore=tests/test_brokers/test_hivemq.py --ignore=tests/test_brokers/test_nanomq.py --ignore=tests/test_brokers/test_emqx.py
       - uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad  # v5
         with:
           files: coverage.xml

--- a/tests/test_brokers/test_emqx.py
+++ b/tests/test_brokers/test_emqx.py
@@ -1,0 +1,26 @@
+from tests.test_brokers._base import BrokerTestBase
+from zmqtt import Subscription
+
+
+class BaseTestEMQX(BrokerTestBase):
+    async def handle_sub_duplicates(
+        self,
+        *,
+        sub: Subscription,
+        n_duplicates: int,
+    ) -> None:
+        for _ in range(n_duplicates):
+            await sub.get_message()
+        assert sub._queue.empty()
+
+
+class TestEMQXV311(BaseTestEMQX):
+    host = "127.0.0.1"
+    port = 1888
+    version = "3.1.1"
+
+
+class TestEMQXV5(BaseTestEMQX):
+    host = "127.0.0.1"
+    port = 1888
+    version = "5.0"


### PR DESCRIPTION
Adds EMQX to the e2e broker matrix — it runs the full `BrokerTestBase` suite (both MQTT 3.1.1 and 5.0), the same as mosquitto/hivemq/artemis/nanomq.

## Why

EMQX is one of the most widely deployed MQTT brokers, and it is what FastStream's own MQTT support runs against — but zmqtt had no EMQX coverage. Adding it found nothing broken (full suite green on both protocol versions), which is exactly the reassurance a matrix is for. It also gives EMQX-specific behaviour a place to be tested e2e: shared `$queue/` subscriptions and MQTT 5 subscription identifiers (companion PRs build on this).

## What

- `tests/test_brokers/test_emqx.py` — `BrokerTestBase` subclass (`TestEMQXV311` + `TestEMQXV5`), same shape as the other brokers; EMQX's overlapping-delivery behaviour matches the mosquitto-style `handle_sub_duplicates`.
- `.github/workflows/tests.yaml` — `emqx/emqx:5` service on host port 1888, added to the broker wait-list. The macOS/Windows jobs ignore it (they run mosquitto only, like the other dockerized brokers).

Verified locally against a real EMQX (6.2.2): the whole suite passes on 3.1.1 and 5.0.
