### PR TITLE
feat: Implement correct request/response pattern using correlation data

### DIFF
--- a/docs/advanced/backpressure.md
+++ b/docs/advanced/backpressure.md
@@ -38,6 +38,14 @@ Set it to `0` (unbounded) when:
 - You buffer messages yourself (e.g. writing to a database in batches).
 - You prefer to drop or log excess rather than slow the broker.
 
+## Request / response
+
+MQTT 5.0 request routing has a separate bound. `max_pending_requests` defaults
+to `1000` and limits how many `request()` futures can be registered at once.
+Calls above the limit wait before publishing, applying backpressure to the
+caller. Unmatched and late responses are never buffered by the request
+dispatcher.
+
 !!! warning
     Applying backpressure affects all topics multiplexed on the same TCP connection. A slow consumer on one `Subscription` will stall delivery to all other subscriptions on the same client. If you need independent flow control per topic, use separate clients.
 

--- a/docs/advanced/request-response.md
+++ b/docs/advanced/request-response.md
@@ -16,10 +16,16 @@ async with create_client("broker", version="5.0") as client:
 
 `request()` handles the full flow automatically:
 
-1. Subscribes to a unique reply topic before publishing.
+1. Acquires the response topic before publishing. When omitted, a unique topic
+   is generated automatically.
 2. Publishes the request with `response_topic` and `correlation_data` set.
-3. Waits for the first message on the reply topic and returns it.
-4. Unsubscribes on return, timeout, or cancellation.
+3. Waits for a message with matching `correlation_data` and returns it.
+4. Releases its response-topic interest on return, timeout, or cancellation.
+
+Messages without correlation data or with a different value do not complete
+the request. If a regular `Subscription` also covers the response topic, it
+still receives every message: request routing observes deliveries without
+consuming the subscription queue.
 
 ## Customising via `PublishProperties`
 
@@ -49,6 +55,12 @@ reply = await client.request(
 )
 ```
 
+The same custom response topic can be shared by concurrent requests as long as
+their correlation data differs. Responses may arrive in any order; each one is
+routed to the matching `request()` call. Reusing the same response topic and
+correlation data while a request is active raises `ValueError` because the two
+responses would be indistinguishable.
+
 ## Implementing a responder
 
 The responder reads `response_topic` and `correlation_data` from the
@@ -58,6 +70,8 @@ incoming message and publishes the reply there:
 async with client.subscribe("services/translate") as sub:
     async for msg in sub:
         assert msg.properties is not None
+        assert msg.properties.response_topic is not None
+        assert msg.properties.correlation_data is not None
         result = translate(msg.payload)
         await client.publish(
             msg.properties.response_topic,
@@ -68,11 +82,29 @@ async with client.subscribe("services/translate") as sub:
         )
 ```
 
+The [MQTT 5.0 request/response flow, section 4.10.1](https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html)
+specifies that when a Request Message contains Correlation Data, the responder
+copies that property into the Response Message. `request()` always includes
+Correlation Data, using the caller-provided value or generating 16 random
+bytes. A compatible responder therefore has to return the same bytes unchanged;
+it must not omit the property or generate a new value.
+
+The broker only forwards Correlation Data; it does not add it to the response
+on behalf of the responder. A response without Correlation Data, or with a
+different value, cannot be associated with the active request. `request()`
+ignores that message and continues waiting for a matching response until its
+timeout. Any regular subscription covering the response topic still receives
+the message.
+
 ## Timeout
 
-`request()` raises `asyncio.TimeoutError` when no reply arrives within
-`timeout` seconds (default `30.0`). The reply subscription is always
-cleaned up, even on timeout or cancellation.
+`request()` raises `asyncio.TimeoutError` when no matching reply arrives within
+`timeout` seconds (default `30.0`). The request's reply-topic interest is
+always cleaned up, even on timeout or cancellation.
+
+Timed-out requests are removed from the correlation dispatcher immediately.
+A late response is not retained in memory; it is ignored by request routing but
+is still delivered to any regular subscription covering that topic.
 
 ```python
 import asyncio
@@ -90,7 +122,22 @@ except asyncio.TimeoutError:
 | `RuntimeError`          | `request()` is called on an MQTT 3.1.1 connection |
 | `MQTTInvalidTopicError` | `properties.response_topic` contains wildcards    |
 | `MQTTDisconnectedError` | Connection is lost while waiting for the reply    |
-| `asyncio.TimeoutError`  | No reply arrives within `timeout` seconds         |
+| `ValueError`            | Topic/correlation pair is already in use          |
+| `asyncio.TimeoutError`  | No matching reply arrives within `timeout`        |
+
+## Request backpressure
+
+The client keeps one future per active request and never buffers unmatched or
+late response messages. `max_pending_requests` bounds the number of active
+futures (default `1000`): additional calls wait for capacity before publishing.
+
+```python
+client = create_client(
+    "broker",
+    version="5.0",
+    max_pending_requests=100,
+)
+```
 
 !!! note
 `request()` is only available on MQTT 5.0 connections. Use

--- a/src/zmqtt/_internal/protocol.py
+++ b/src/zmqtt/_internal/protocol.py
@@ -4,7 +4,7 @@ import asyncio
 import contextlib
 import dataclasses
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable
 from typing import Final, Literal, cast
 
 from zmqtt._internal import topic_matching
@@ -46,6 +46,41 @@ from zmqtt.errors import (
 log = logging.getLogger(__name__)
 
 
+class _SubscriptionGuard:
+    def __init__(self) -> None:
+        self.lock = asyncio.Lock()
+        self.users = 0
+
+
+class _SubscriptionGuards:
+    """Serialize ownership changes only when topic filters overlap exactly."""
+
+    def __init__(self) -> None:
+        self._guards: dict[str, _SubscriptionGuard] = {}
+
+    @contextlib.asynccontextmanager
+    async def hold(self, filters: Iterable[str]) -> AsyncGenerator[None]:
+        entries: list[tuple[str, _SubscriptionGuard]] = []
+        for filter_ in sorted(set(filters)):
+            guard = self._guards.setdefault(filter_, _SubscriptionGuard())
+            guard.users += 1
+            entries.append((filter_, guard))
+
+        acquired = 0
+        try:
+            for _, guard in entries:
+                await guard.lock.acquire()
+                acquired += 1
+            yield
+        finally:
+            for _, guard in reversed(entries[:acquired]):
+                guard.lock.release()
+            for filter_, guard in entries:
+                guard.users -= 1
+                if guard.users == 0:
+                    self._guards.pop(filter_, None)
+
+
 def _raise_on_rejected_filters(filters: list[SubscriptionRequest], suback: SubAck) -> None:
     """Surface SUBACK failure codes (>= 0x80) instead of ignoring them.
 
@@ -80,6 +115,7 @@ class MQTTProtocol:
         connect_timeout: float = 30.0,
         version: Literal["3.1.1", "5.0"] = "3.1.1",
         stripped_prefixes: tuple[str, ...] = topic_matching._DEFAULT_STRIPPED_PREFIXES,
+        response_observer: Callable[[Message], None] | None = None,
     ) -> None:
         self._transport = transport
         self._state = state
@@ -88,8 +124,10 @@ class MQTTProtocol:
         self._connect_timeout = connect_timeout
         self._version: Final = version
         self._stripped_prefixes = stripped_prefixes
+        self._response_observer = response_observer
         self._buf = PacketBuffer(version=version)
         self._ping_waiters: list[asyncio.Future[None]] = []
+        self._subscription_guards = _SubscriptionGuards()
         self._disconnecting = False
         self._dead = False
         self.started_event = asyncio.Event()
@@ -254,9 +292,22 @@ class MQTTProtocol:
         ``_deliver`` attribute the message to the exact subscription that matched
         instead of guessing by filter specificity.
         """
-        self._ensure_alive()
-        loop = asyncio.get_running_loop()
-        pid = self._state.packet_ids.acquire()
+        async with self._subscription_guards.hold(req.topic_filter for req in filters):
+            return await self._subscribe(
+                filters,
+                auto_ack=auto_ack,
+                queue_maxsize=queue_maxsize,
+                subscription_identifier=subscription_identifier,
+            )
+
+    async def _subscribe(
+        self,
+        filters: list[SubscriptionRequest],
+        *,
+        auto_ack: bool,
+        queue_maxsize: int,
+        subscription_identifier: int | None,
+    ) -> tuple[SubAck, dict[str, asyncio.Queue[Message]]]:
         new_entries: dict[str, SubscriptionEntry] = {}
 
         for req in filters:
@@ -272,6 +323,78 @@ class MQTTProtocol:
                 )
 
         self._state.subscriptions.add_many(new_entries)
+        subscribed = False
+        try:
+            suback = await self._send_subscribe(filters, subscription_identifier)
+            subscribed = True
+            return suback, {f: entry.queue for f, entry in new_entries.items()}
+        finally:
+            if not subscribed:
+                for f in new_entries:
+                    self._state.subscriptions.remove(f)
+
+    async def unsubscribe(self, filters: list[str]) -> UnsubAck | None:
+        """Remove queues and unsubscribe filters without response observers.
+
+        Returns ``None`` when every broker subscription must stay active for
+        request/response routing.
+        """
+        async with self._subscription_guards.hold(filters):
+            return await self._unsubscribe(filters)
+
+    async def _unsubscribe(self, filters: list[str]) -> UnsubAck | None:
+        self._ensure_alive()
+        observed_filters = [f for f in filters if self._state.subscriptions.has_response_observer(f)]
+        broker_filters = [f for f in filters if f not in observed_filters]
+        for f in filters:
+            self._state.subscriptions.remove(f)
+
+        unsuback = await self._send_unsubscribe(broker_filters) if broker_filters else None
+        if observed_filters:
+            requests = [SubscriptionRequest(topic_filter=f, qos=QoS.AT_MOST_ONCE) for f in observed_filters]
+            await self._send_subscribe(requests, subscription_identifier=None)
+        return unsuback
+
+    async def add_response_observer(self, topic: str) -> None:
+        """Keep an exact response topic subscribed without claiming its messages."""
+        async with self._subscription_guards.hold([topic]):
+            await self._add_response_observer(topic)
+
+    async def _add_response_observer(self, topic: str) -> None:
+        self._ensure_alive()
+        if not self._state.subscriptions.add_response_observer(topic):
+            return
+        if self._state.subscriptions.contains(topic):
+            return
+        request = SubscriptionRequest(topic_filter=topic, qos=QoS.AT_MOST_ONCE)
+        subscribed = False
+        try:
+            await self._send_subscribe([request], subscription_identifier=None)
+            subscribed = True
+        finally:
+            if not subscribed:
+                self._state.subscriptions.remove_response_observer(topic)
+
+    async def remove_response_observer(self, topic: str) -> None:
+        """Release an exact response topic unless an application owns it."""
+        async with self._subscription_guards.hold([topic]):
+            await self._remove_response_observer(topic)
+
+    async def _remove_response_observer(self, topic: str) -> None:
+        if not self._state.subscriptions.remove_response_observer(topic):
+            return
+        if self._state.subscriptions.contains(topic) or self._dead:
+            return
+        await self._send_unsubscribe([topic])
+
+    async def _send_subscribe(
+        self,
+        filters: list[SubscriptionRequest],
+        subscription_identifier: int | None,
+    ) -> SubAck:
+        self._ensure_alive()
+        loop = asyncio.get_running_loop()
+        pid = self._state.packet_ids.acquire()
         future: asyncio.Future[SubAck] = loop.create_future()
         self._state.pending_subs[pid] = future
         properties = (
@@ -279,49 +402,38 @@ class MQTTProtocol:
             if subscription_identifier is not None
             else None
         )
-        await self._send(
-            self._encode(
-                Subscribe(packet_id=pid, subscriptions=tuple(filters), properties=properties),
-            ),
-        )
-
-        log.debug("Sent SUBSCRIBE", extra={"packet_id": pid})
-
         try:
+            await self._send(
+                self._encode(
+                    Subscribe(packet_id=pid, subscriptions=tuple(filters), properties=properties),
+                ),
+            )
+            log.debug("Sent SUBSCRIBE", extra={"packet_id": pid})
             suback = await future
             _raise_on_rejected_filters(filters, suback)
-        except Exception:
-            for f in new_entries:
-                self._state.subscriptions.remove(f)
-            raise
+            return suback
         finally:
             self._state.pending_subs.pop(pid, None)
             self._state.packet_ids.release(pid)
 
-        return suback, {f: entry.queue for f, entry in new_entries.items()}
-
-    async def unsubscribe(self, filters: list[str]) -> UnsubAck:
-        """Send UNSUBSCRIBE, remove queues from state, return UnsubAck."""
+    async def _send_unsubscribe(self, filters: list[str]) -> UnsubAck:
         self._ensure_alive()
         pid = self._state.packet_ids.acquire()
         loop = asyncio.get_running_loop()
         future: asyncio.Future[UnsubAck] = loop.create_future()
         self._state.pending_unsubs[pid] = future
-        await self._send(
-            encode(
-                Unsubscribe(packet_id=pid, topic_filters=tuple(filters)),
-                version=self._version,
-            ),
-        )
-        log.debug("Sent UNSUBSCRIBE", extra={"packet_id": pid})
         try:
-            unsuback = await future
+            await self._send(
+                encode(
+                    Unsubscribe(packet_id=pid, topic_filters=tuple(filters)),
+                    version=self._version,
+                ),
+            )
+            log.debug("Sent UNSUBSCRIBE", extra={"packet_id": pid})
+            return await future
         finally:
             self._state.pending_unsubs.pop(pid, None)
             self._state.packet_ids.release(pid)
-            for f in filters:
-                self._state.subscriptions.remove(f)
-        return unsuback
 
     async def ping(self, timeout: float | None = None) -> float:
         """Send PINGREQ and return RTT in seconds when PINGRESP is received."""
@@ -556,6 +668,9 @@ class MQTTProtocol:
         ack_callback: Callable[[], Awaitable[None]] | None,
     ) -> None:
         selection = self._select_subscription(publish)
+        has_response_observer = self._state.subscriptions.has_response_observer(publish.topic)
+        if has_response_observer and self._response_observer is not None:
+            self._response_observer(self._make_message(publish))
         if selection.identifier_missing:
             identifier = publish.properties.subscription_identifier if publish.properties else None
             log.warning(
@@ -572,9 +687,19 @@ class MQTTProtocol:
 
         recipient = selection.recipient
         if recipient is None:
-            log.warning("No subscriber for topic %r", publish.topic)
+            if not has_response_observer:
+                log.warning("No subscriber for topic %r", publish.topic)
             return
         await self._put_message(publish, [recipient], ack_callback)
+
+    def _make_message(self, publish: Publish) -> Message:
+        return Message(
+            topic=publish.topic,
+            payload=publish.payload,
+            qos=publish.qos,
+            retain=publish.retain,
+            properties=publish.properties,
+        )
 
     async def _put_message(
         self,
@@ -583,13 +708,7 @@ class MQTTProtocol:
         ack_callback: Callable[[], Awaitable[None]] | None,
     ) -> None:
         for filter_, entry in recipients:
-            msg = Message(
-                topic=publish.topic,
-                payload=publish.payload,
-                qos=publish.qos,
-                retain=publish.retain,
-                properties=publish.properties,
-            )
+            msg = self._make_message(publish)
             if not entry.auto_ack and ack_callback is not None:
                 msg._ack_callback = ack_callback
             await entry.queue.put(msg)

--- a/src/zmqtt/_internal/request_response.py
+++ b/src/zmqtt/_internal/request_response.py
@@ -1,0 +1,189 @@
+"""Correlation-based routing for MQTT 5.0 request/response messages."""
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import TypeAlias
+
+from zmqtt._internal.protocol import MQTTProtocol
+from zmqtt._internal.types.message import Message
+from zmqtt.errors import MQTTDisconnectedError
+
+_RequestKey: TypeAlias = tuple[str, bytes]
+
+
+@dataclass(slots=True)
+class _PendingRequest:
+    """A registered response waiter with explicit, idempotent cleanup."""
+
+    future: asyncio.Future[Message]
+    _dispatcher: "_RequestDispatcher"
+    _key: _RequestKey
+    _closed: bool = field(default=False, init=False)
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            await self._dispatcher.unregister(self._key, self.future)
+        finally:
+            if self.future.done() and not self.future.cancelled():
+                self.future.exception()
+
+
+@dataclass(slots=True)
+class _TopicInterest:
+    """Shared broker-subscription readiness for one response topic."""
+
+    refcount: int = 0
+    ready: asyncio.Task[None] | None = None
+
+
+class _RequestDispatcher:
+    """Route responses to request futures without consuming subscription queues.
+
+    Only active waiters are retained. Incoming messages without a matching
+    waiter are never buffered, so late and unsolicited responses cannot grow
+    dispatcher state.
+    """
+
+    def __init__(self, max_pending_requests: int) -> None:
+        if max_pending_requests <= 0:
+            msg = "max_pending_requests must be positive"
+            raise ValueError(msg)
+        self._capacity = asyncio.Semaphore(max_pending_requests)
+        self._pending: dict[_RequestKey, asyncio.Future[Message]] = {}
+        self._topics: dict[str, _TopicInterest] = {}
+        self._protocol: MQTTProtocol | None = None
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._pending)
+
+    def bind(self, protocol: MQTTProtocol) -> None:
+        """Bind the dispatcher to the current connection's protocol engine."""
+        self._protocol = protocol
+        for interest in self._topics.values():
+            interest.ready = None
+
+    async def restore(self) -> None:
+        """Restore response-topic interests after protocol reconnection."""
+        for topic, interest in tuple(self._topics.items()):
+            if interest.refcount > 0:
+                await asyncio.shield(self._ensure_topic_ready(topic, interest))
+
+    async def register(self, topic: str, correlation_data: bytes) -> _PendingRequest:
+        """Register a bounded response waiter before its request is published."""
+        await self._capacity.acquire()
+        key = (topic, correlation_data)
+        future: asyncio.Future[Message] | None = None
+        registered = False
+        try:
+            self._ensure_unique(key)
+            self._require_protocol()
+
+            interest = self._topics.get(topic)
+            if interest is None:
+                interest = _TopicInterest()
+                self._topics[topic] = interest
+
+            future = asyncio.get_running_loop().create_future()
+            self._pending[key] = future
+            interest.refcount += 1
+            await asyncio.shield(self._ensure_topic_ready(topic, interest))
+            registered = True
+            return _PendingRequest(
+                future=future,
+                _dispatcher=self,
+                _key=key,
+            )
+        finally:
+            if not registered:
+                if future is None:
+                    self._capacity.release()
+                else:
+                    await self.unregister(key, future)
+
+    def dispatch(self, message: Message) -> None:
+        """Resolve a matching waiter without suppressing normal delivery."""
+        properties = message.properties
+        if properties is None or properties.correlation_data is None:
+            return
+
+        future = self._pending.get((message.topic, properties.correlation_data))
+        if future is not None and not future.done():
+            future.set_result(message)
+
+    async def unregister(
+        self,
+        key: _RequestKey,
+        future: asyncio.Future[Message],
+    ) -> None:
+        """Remove one waiter and release its response-topic interest."""
+        removed = False
+        try:
+            if self._pending.get(key) is not future:
+                return
+
+            removed = True
+            del self._pending[key]
+            if not future.done():
+                future.cancel()
+
+            topic = key[0]
+            interest = self._topics[topic]
+            interest.refcount -= 1
+            if interest.refcount > 0:
+                return
+
+            observer_active = False
+            try:
+                ready = interest.ready
+                if ready is not None:
+                    await asyncio.shield(ready)
+                    observer_active = True
+            finally:
+                # A new waiter may have joined while the initial SUBACK was
+                # pending. In that case it inherits the same topic interest.
+                if interest.refcount == 0 and self._topics.get(topic) is interest:
+                    del self._topics[topic]
+                    protocol = self._protocol
+                    if observer_active and protocol is not None:
+                        await protocol.remove_response_observer(topic)
+        finally:
+            if removed:
+                self._capacity.release()
+
+    async def cancel_pending(self) -> None:
+        """Fail and forget every waiter when the client shuts down."""
+        pending = tuple(self._pending.values())
+        ready_tasks = tuple(interest.ready for interest in self._topics.values() if interest.ready is not None)
+        self._pending.clear()
+        self._topics.clear()
+        self._protocol = None
+        for future in pending:
+            if not future.done():
+                future.set_exception(MQTTDisconnectedError("Client disconnected"))
+            self._capacity.release()
+        for task in ready_tasks:
+            task.cancel()
+        await asyncio.gather(*ready_tasks, return_exceptions=True)
+
+    def _ensure_topic_ready(self, topic: str, interest: _TopicInterest) -> asyncio.Task[None]:
+        ready = interest.ready
+        if ready is None:
+            protocol = self._require_protocol()
+            ready = asyncio.create_task(protocol.add_response_observer(topic))
+            interest.ready = ready
+        return ready
+
+    def _require_protocol(self) -> MQTTProtocol:
+        if self._protocol is None:
+            msg = "Not connected"
+            raise MQTTDisconnectedError(msg)
+        return self._protocol
+
+    def _ensure_unique(self, key: _RequestKey) -> None:
+        if key in self._pending:
+            msg = "correlation_data is already in use for this response_topic"
+            raise ValueError(msg)

--- a/src/zmqtt/_internal/subscription_index.py
+++ b/src/zmqtt/_internal/subscription_index.py
@@ -33,6 +33,7 @@ class SubscriptionIndex:
         self._root = _Node()
         self._entries: dict[str, SubscriptionEntry] = {}
         self._by_identifier: dict[int, dict[str, SubscriptionEntry]] = {}
+        self._response_observers: set[str] = set()
 
     def add(self, filter_: str, entry: SubscriptionEntry) -> None:
         if filter_ in self._entries:
@@ -52,6 +53,25 @@ class SubscriptionIndex:
 
     def contains(self, filter_: str) -> bool:
         return filter_ in self._entries
+
+    def add_response_observer(self, topic: str) -> bool:
+        """Register an exact response-topic observer.
+
+        Returns ``True`` only for the first observer on this connection.
+        """
+        if topic in self._response_observers:
+            return False
+        self._response_observers.add(topic)
+        return True
+
+    def remove_response_observer(self, topic: str) -> bool:
+        if topic not in self._response_observers:
+            return False
+        self._response_observers.remove(topic)
+        return True
+
+    def has_response_observer(self, topic: str) -> bool:
+        return topic in self._response_observers
 
     def get(self, filter_: str, default: SubscriptionEntry | None = None) -> SubscriptionEntry | None:
         return self._entries.get(filter_, default)
@@ -77,6 +97,7 @@ class SubscriptionIndex:
         self._root = _Node()
         self._entries.clear()
         self._by_identifier.clear()
+        self._response_observers.clear()
 
     def add_many(self, entries: Mapping[str, SubscriptionEntry]) -> None:
         for filter_, entry in entries.items():

--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -21,6 +21,7 @@ from zmqtt._internal.packets.properties import (
 from zmqtt._internal.packets.publish import Publish
 from zmqtt._internal.packets.subscribe import SubscriptionRequest
 from zmqtt._internal.protocol import MQTTProtocol
+from zmqtt._internal.request_response import _RequestDispatcher
 from zmqtt._internal.state import SessionState
 from zmqtt._internal.topic_matching import _DEFAULT_STRIPPED_PREFIXES
 from zmqtt._internal.transport.base import Transport
@@ -314,6 +315,7 @@ class MQTTClient:
         version: Literal["3.1.1", "5.0"] = "3.1.1",
         session_expiry_interval: int = 0,
         stripped_prefixes: tuple[str, ...] = _DEFAULT_STRIPPED_PREFIXES,
+        max_pending_requests: int = 1000,
     ) -> None:
         """Create an MQTT client.
 
@@ -355,6 +357,8 @@ class MQTTClient:
                 broker-specific decorator here instead of patching the library.
                 ``$share/<group>/`` is always handled; real namespaces the broker
                 delivers on unchanged (e.g. ``$SYS``) must not be listed.
+            max_pending_requests: Maximum concurrent MQTT 5.0 ``request()`` calls.
+                Additional calls wait until capacity is available.
         """
         if not mqtt_connect_timeout > 0:
             msg = "mqtt_connect_timeout must be positive"
@@ -373,6 +377,7 @@ class MQTTClient:
         self._version: Final = version
         self._session_expiry_interval = session_expiry_interval
         self._stripped_prefixes = stripped_prefixes
+        self._request_dispatcher = _RequestDispatcher(max_pending_requests)
         self._protocol: MQTTProtocol | None = None
         self._subscriptions: list[Subscription] = []
         self._run_task: asyncio.Task[None] | None = None
@@ -386,6 +391,7 @@ class MQTTClient:
     async def __aexit__(self, *exc: object) -> None:
         """Disconnect cleanly and cancel the run loop."""
         async with defer_cancellation():
+            await self._request_dispatcher.cancel_pending()
             if self._run_task is not None:
                 self._run_task.cancel()
                 await asyncio.gather(self._run_task, return_exceptions=True)
@@ -567,7 +573,9 @@ class MQTTClient:
         """Send a request and wait for exactly one reply (MQTT 5.0 only).
 
         Publishes *payload* to *topic* with a ``response_topic`` property, then
-        waits for the first message that arrives on that topic and returns it.
+        waits for a message whose ``correlation_data`` matches the request.
+        Other messages on the response topic remain available to regular
+        subscriptions and do not complete this request.
 
         Both ``response_topic`` and ``correlation_data`` are taken from
         *properties* when set; otherwise they are generated automatically
@@ -586,13 +594,16 @@ class MQTTClient:
                 the responder.
 
         Returns:
-            The first ``Message`` received on the reply topic.
+            The matching response ``Message``.
 
         Raises:
             RuntimeError: If the client is not using MQTT 5.0.
             MQTTInvalidTopicError: If ``properties.response_topic`` contains wildcards.
             MQTTDisconnectedError: If the connection is lost while waiting.
-            asyncio.TimeoutError: If no reply arrives within *timeout* seconds.
+            ValueError: If the same response topic and correlation data are
+                already used by another active request.
+            asyncio.TimeoutError: If no matching reply arrives within *timeout*
+                seconds.
         """
         if self._version != "5.0":
             msg = "request() requires MQTT 5.0"
@@ -621,9 +632,12 @@ class MQTTClient:
                 correlation_data=corr,
             )
 
-        async with self.subscribe(reply_topic, receive_buffer_size=1) as sub:
+        pending = await self._request_dispatcher.register(reply_topic, corr)
+        try:
             await self.publish(topic, payload, qos=qos, properties=req_props)
-            return await asyncio.wait_for(sub.get_message(), timeout=timeout)
+            return await asyncio.wait_for(pending.future, timeout=timeout)
+        finally:
+            await pending.close()
 
     async def auth(self, method: str, data: bytes | None = None) -> None:
         """Send an AUTH packet for enhanced authentication (MQTT 5.0 only).
@@ -655,6 +669,7 @@ class MQTTClient:
             connect_timeout=self._mqtt_connect_timeout,
             version=self._version,
             stripped_prefixes=self._stripped_prefixes,
+            response_observer=self._request_dispatcher.dispatch,
         )
         connect_props = None
         if self._version == "5.0":
@@ -675,6 +690,7 @@ class MQTTClient:
             await transport.close()
             raise
         self._protocol = protocol
+        self._request_dispatcher.bind(protocol)
 
     async def _connect_with_retry(self) -> None:
         delay = self._reconnect.initial_delay
@@ -707,11 +723,12 @@ class MQTTClient:
                 # Run the protocol as a sub-task so _read_loop is live while we
                 # re-subscribe.  For the first connection subs_to_restore is empty,
                 # so this collapses to the original "await protocol.run()" pattern.
+                await self._protocol.started_event.wait()
                 if subs_to_restore:
-                    await self._protocol.started_event.wait()
                     for sub in subs_to_restore:
                         await sub._reconnect(self._protocol)
                     subs_to_restore = []
+                await self._request_dispatcher.restore()
                 await protocol_run_task
 
             except (MQTTDisconnectedError, MQTTTimeoutError):
@@ -745,6 +762,7 @@ def create_client(
     mqtt_connect_timeout: float = ...,
     transport_factory: TransportFactory | None = ...,
     session_expiry_interval: int = ...,
+    max_pending_requests: int = ...,
 ) -> MQTTClientV311: ...
 
 
@@ -763,6 +781,7 @@ def create_client(
     mqtt_connect_timeout: float = ...,
     transport_factory: TransportFactory | None = ...,
     session_expiry_interval: int = ...,
+    max_pending_requests: int = ...,
     version: Literal["3.1.1"],
 ) -> MQTTClientV311: ...
 
@@ -782,6 +801,7 @@ def create_client(
     mqtt_connect_timeout: float = ...,
     transport_factory: TransportFactory | None = ...,
     session_expiry_interval: int = ...,
+    max_pending_requests: int = ...,
     version: Literal["5.0"],
 ) -> MQTTClientV5: ...
 
@@ -800,6 +820,7 @@ def create_client(
     mqtt_connect_timeout: float = 30.0,
     transport_factory: TransportFactory | None = None,
     session_expiry_interval: int = 0,
+    max_pending_requests: int = 1000,
     version: Literal["3.1.1", "5.0"] = "3.1.1",
 ) -> MQTTClientV311 | MQTTClientV5:
     """Create a version-typed MQTT client.
@@ -821,4 +842,5 @@ def create_client(
         transport_factory=transport_factory,
         version=version,
         session_expiry_interval=session_expiry_interval,
+        max_pending_requests=max_pending_requests,
     )

--- a/tests/test_brokers/_base.py
+++ b/tests/test_brokers/_base.py
@@ -471,6 +471,205 @@ class BrokerTestBase(abc.ABC):
         assert reply.properties is not None
         assert reply.properties.correlation_data is not None
 
+    async def test_concurrent_requests_share_response_topic(self, topic: str) -> None:
+        if self.version != "5.0":
+            return
+
+        response_topic = topic + "/responses"
+        async with (
+            MQTTClient(self.host, self.port, version=self.version) as requester,
+            MQTTClient(self.host, self.port, version=self.version) as responder,
+            responder.subscribe(topic) as req_sub,
+        ):
+
+            async def respond_in_reverse_order() -> None:
+                requests = [await asyncio.wait_for(req_sub.get_message(), timeout=5.0) for _ in range(2)]
+                await responder.publish(response_topic, b"no-correlation")
+                await responder.publish(
+                    response_topic,
+                    b"unknown-correlation",
+                    properties=PublishProperties(correlation_data=b"unknown"),
+                )
+                for msg in reversed(requests):
+                    assert msg.properties is not None
+                    assert msg.properties.response_topic == response_topic
+                    await responder.publish(
+                        response_topic,
+                        b"reply-" + msg.payload,
+                        properties=PublishProperties(
+                            correlation_data=msg.properties.correlation_data,
+                        ),
+                    )
+
+            responder_task = asyncio.create_task(respond_in_reverse_order())
+            first, second = await asyncio.gather(
+                requester.request(
+                    topic,
+                    b"first",
+                    properties=PublishProperties(
+                        response_topic=response_topic,
+                        correlation_data=b"corr-first",
+                    ),
+                    timeout=5.0,
+                ),
+                requester.request(
+                    topic,
+                    b"second",
+                    properties=PublishProperties(
+                        response_topic=response_topic,
+                        correlation_data=b"corr-second",
+                    ),
+                    timeout=5.0,
+                ),
+            )
+            await responder_task
+
+        assert first.payload == b"reply-first"
+        assert second.payload == b"reply-second"
+
+    async def test_request_response_does_not_steal_from_regular_subscription(self, topic: str) -> None:
+        if self.version != "5.0":
+            return
+
+        response_topic = topic + "/responses"
+        correlation_data = b"request-correlation"
+        async with (
+            MQTTClient(self.host, self.port, version=self.version) as requester,
+            MQTTClient(self.host, self.port, version=self.version) as responder,
+            responder.subscribe(topic) as req_sub,
+        ):
+            response_sub = requester.subscribe(response_topic)
+            await response_sub.start()
+
+            async def respond() -> None:
+                msg = await asyncio.wait_for(req_sub.get_message(), timeout=5.0)
+                assert msg.properties is not None
+                await responder.publish(
+                    response_topic,
+                    b"response",
+                    properties=PublishProperties(
+                        correlation_data=msg.properties.correlation_data,
+                    ),
+                )
+
+            responder_task = asyncio.create_task(respond())
+            reply = await requester.request(
+                topic,
+                b"request",
+                properties=PublishProperties(
+                    response_topic=response_topic,
+                    correlation_data=correlation_data,
+                ),
+                timeout=5.0,
+            )
+            regular = await asyncio.wait_for(response_sub.get_message(), timeout=5.0)
+            await responder_task
+
+            # The regular subscription still owns the topic after the
+            # request observer has left.
+            await responder.publish(response_topic, b"ordinary")
+            ordinary = await asyncio.wait_for(response_sub.get_message(), timeout=5.0)
+
+            request_seen = asyncio.Event()
+            send_response = asyncio.Event()
+
+            async def respond_after_regular_subscription_stops() -> None:
+                msg = await asyncio.wait_for(req_sub.get_message(), timeout=5.0)
+                assert msg.properties is not None
+                request_seen.set()
+                await send_response.wait()
+                await responder.publish(
+                    response_topic,
+                    b"response-after-stop",
+                    properties=PublishProperties(
+                        correlation_data=msg.properties.correlation_data,
+                    ),
+                )
+
+            responder_task = asyncio.create_task(respond_after_regular_subscription_stops())
+            request_task = asyncio.create_task(
+                requester.request(
+                    topic,
+                    b"request-after-stop",
+                    properties=PublishProperties(
+                        response_topic=response_topic,
+                        correlation_data=b"corr-after-stop",
+                    ),
+                    timeout=5.0,
+                ),
+            )
+            await asyncio.wait_for(request_seen.wait(), timeout=5.0)
+            await response_sub.stop()
+            send_response.set()
+            reply_after_stop = await request_task
+            await responder_task
+
+        assert reply.payload == b"response"
+        assert regular.payload == b"response"
+        assert ordinary.payload == b"ordinary"
+        assert reply_after_stop.payload == b"response-after-stop"
+
+    async def test_request_backpressure_delays_publish(self, topic: str) -> None:
+        if self.version != "5.0":
+            return
+
+        response_topic = topic + "/responses"
+        async with (
+            MQTTClient(self.host, self.port, version=self.version, max_pending_requests=1) as requester,
+            MQTTClient(self.host, self.port, version=self.version) as responder,
+            responder.subscribe(topic) as req_sub,
+        ):
+            first_task = asyncio.create_task(
+                requester.request(
+                    topic,
+                    b"first",
+                    properties=PublishProperties(
+                        response_topic=response_topic,
+                        correlation_data=b"corr-first",
+                    ),
+                    timeout=5.0,
+                ),
+            )
+            first_request = await asyncio.wait_for(req_sub.get_message(), timeout=5.0)
+
+            second_task = asyncio.create_task(
+                requester.request(
+                    topic,
+                    b"second",
+                    properties=PublishProperties(
+                        response_topic=response_topic,
+                        correlation_data=b"corr-second",
+                    ),
+                    timeout=5.0,
+                ),
+            )
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(req_sub.get_message(), timeout=0.2)
+
+            assert first_request.properties is not None
+            await responder.publish(
+                response_topic,
+                b"reply-first",
+                properties=PublishProperties(
+                    correlation_data=first_request.properties.correlation_data,
+                ),
+            )
+            first_reply = await first_task
+
+            second_request = await asyncio.wait_for(req_sub.get_message(), timeout=5.0)
+            assert second_request.properties is not None
+            await responder.publish(
+                response_topic,
+                b"reply-second",
+                properties=PublishProperties(
+                    correlation_data=second_request.properties.correlation_data,
+                ),
+            )
+            second_reply = await second_task
+
+        assert first_reply.payload == b"reply-first"
+        assert second_reply.payload == b"reply-second"
+
     async def test_request_timeout(self, topic: str) -> None:
         if self.version != "5.0":
             return
@@ -479,12 +678,49 @@ class BrokerTestBase(abc.ABC):
             with pytest.raises(asyncio.TimeoutError):
                 await client.request(topic + "/nobody-listening", b"ping", timeout=0.3)
 
-    async def test_request_reply_topic_unsubscribed_after_timeout(self, topic: str) -> None:
+    async def test_late_response_after_timeout_is_not_retained(self, topic: str) -> None:
         if self.version != "5.0":
             return
 
-        async with MQTTClient(self.host, self.port, version=self.version) as client:
-            sub_count_before = len(client._subscriptions)
-            with contextlib.suppress(asyncio.TimeoutError):
-                await client.request(topic + "/void", b"x", timeout=0.1)
-            assert len(client._subscriptions) == sub_count_before
+        response_topic = topic + "/late-response"
+        request_seen = asyncio.Event()
+        send_response = asyncio.Event()
+        async with (
+            MQTTClient(self.host, self.port, version=self.version) as requester,
+            MQTTClient(self.host, self.port, version=self.version) as responder,
+            requester.subscribe(response_topic) as response_sub,
+            responder.subscribe(topic) as req_sub,
+        ):
+
+            async def respond_late() -> None:
+                msg = await asyncio.wait_for(req_sub.get_message(), timeout=5.0)
+                assert msg.properties is not None
+                request_seen.set()
+                await send_response.wait()
+                await responder.publish(
+                    response_topic,
+                    b"late",
+                    properties=PublishProperties(
+                        correlation_data=msg.properties.correlation_data,
+                    ),
+                )
+
+            responder_task = asyncio.create_task(respond_late())
+            request_task = asyncio.create_task(
+                requester.request(
+                    topic,
+                    b"request",
+                    timeout=0.3,
+                    properties=PublishProperties(response_topic=response_topic),
+                ),
+            )
+            await asyncio.wait_for(request_seen.wait(), timeout=5.0)
+            with pytest.raises(asyncio.TimeoutError):
+                await request_task
+            assert requester._request_dispatcher.pending_count == 0
+
+            send_response.set()
+            late = await asyncio.wait_for(response_sub.get_message(), timeout=5.0)
+            await responder_task
+
+        assert late.payload == b"late"

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -7,3 +7,8 @@ async def test_request_raises_on_v311() -> None:
     client = MQTTClient("localhost", version="3.1.1")
     with pytest.raises(RuntimeError, match=r"MQTT 5.0"):
         await client.request("t", b"x")
+
+
+def test_max_pending_requests_must_be_positive() -> None:
+    with pytest.raises(ValueError, match="max_pending_requests"):
+        MQTTClient("localhost", max_pending_requests=0)


### PR DESCRIPTION
## Summary

This PR makes MQTT 5 request/response handling safe for concurrent requests. Responses are now matched by the pair of `response_topic` and `correlation_data` instead of returning the first message received on a reply topic. This allows multiple requests to share one response topic and complete correctly even when replies arrive out of order.

## Implementation

- Introduces a dedicated request dispatcher that keeps one future per active `(response topic, correlation data)` pair. Unknown, malformed, and late responses are not buffered, which keeps memory usage bounded.
- Registers each waiter before publishing its request, preventing fast responses from arriving before the requester is ready.
- Tracks response-topic interests with reference counts and shares the same broker subscription between concurrent requests. The subscription is released only after its final waiter exits.
- Observes response messages without consuming regular subscription queues. If an application also subscribes to the response topic, it still receives the message normally.
- Coordinates regular subscriptions and internal response observers with per-topic guards. Operations for the same exact filter are serialized to keep local ownership and broker state consistent, while unrelated topics remain concurrent.
- Restores active response-topic interests after reconnect and cancels pending waiters during client shutdown.
- Adds `max_pending_requests` (default: `1000`) to apply backpressure before publishing when too many requests are already active. Reusing an active topic/correlation pair raises `ValueError` because the replies would be indistinguishable.

## Tests and documentation

The broker test suite now covers concurrent requests sharing a response topic, out-of-order replies, coexistence with regular subscriptions, request backpressure, timeouts, and late responses. The request/response and backpressure documentation has been updated to describe correlation requirements, lifecycle behavior, and the new configuration option.


## Validation

<!-- Which checks did you run? -->

- [x] Tests were added or updated when behavior changed
- [x] Documentation was updated when the public API changed
- [x] The PR title follows Conventional Commits, for example `feat(client): add reconnect timeout`
