### PR TITLE
docs: correct ack, reconnect, and request semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,12 @@ are transparently re-registered after reconnect — your `async for` loop keeps 
 
 ## MQTT 5.0
 
-Pass `version=5` to use MQTT 5.0. Properties are typed dataclasses:
+Pass `version="5.0"` to use MQTT 5.0. Properties are typed dataclasses:
 
 ```python
-from zmqtt import MQTTClient
-from zmqtt._internal.packets.properties import PublishProperties
+from zmqtt import MQTTClient, PublishProperties
 
-async with MQTTClient("broker.example.com", version=5) as client:
+async with MQTTClient("broker.example.com", version="5.0") as client:
     props = PublishProperties(content_type="application/json")
     await client.publish("topic", b'{"value": 42}', properties=props)
 ```

--- a/docs/advanced/backpressure.md
+++ b/docs/advanced/backpressure.md
@@ -43,8 +43,7 @@ Set it to `0` (unbounded) when:
 MQTT 5.0 request routing has a separate bound. `max_pending_requests` defaults
 to `1000` and limits how many `request()` futures can be registered at once.
 Calls above the limit wait before publishing, applying backpressure to the
-caller. Unmatched and late responses are never buffered by the request
-dispatcher.
+caller. Unmatched and late responses are never buffered.
 
 !!! warning
     Applying backpressure affects all topics multiplexed on the same TCP connection. A slow consumer on one `Subscription` will stall delivery to all other subscriptions on the same client. If you need independent flow control per topic, use separate clients.

--- a/docs/advanced/manual-ack.md
+++ b/docs/advanced/manual-ack.md
@@ -4,7 +4,9 @@ By default, zmqtt acknowledges incoming messages automatically as soon as they a
 
 ## Why use manual ack
 
-Use `auto_ack=False` when you need a **process-before-ack** guarantee: the message should not be considered delivered until your processing is complete. If your process crashes before calling `ack()`, the broker (for QoS 1) or the library (for QoS 2) will redeliver.
+Use `auto_ack=False` when acknowledgement must happen **after processing**. The broker does not receive the acknowledgement until your handler calls `ack()`.
+
+Manual acknowledgement controls this ordering, but it does not make the handler transactional. Redelivery after a lost connection or process restart also depends on the broker session configuration.
 
 !!! note
     Manual ack only has effect at QoS 1 (`AT_LEAST_ONCE`) or QoS 2 (`EXACTLY_ONCE`). At QoS 0 (`AT_MOST_ONCE`) there is no acknowledgement protocol, so `auto_ack=False` is a no-op. See [QoS levels](../publishing.md#qos-levels) for the delivery guarantees.
@@ -22,7 +24,7 @@ async with client.subscribe("jobs/#", qos=QoS.AT_LEAST_ONCE, auto_ack=False) as 
 
 ## QoS 1 semantics
 
-For QoS 1 messages (`AT_LEAST_ONCE`), `ack()` sends PUBACK to the broker. Until PUBACK is sent, the broker may retransmit the message (e.g. on reconnect). Each retransmission appears as a new `Message` in your queue.
+For QoS 1 messages (`AT_LEAST_ONCE`), `ack()` sends PUBACK to the broker. Until PUBACK is sent, the broker may retransmit the message. Each retransmission appears as a new `Message` in your queue, so handlers should be idempotent.
 
 ## QoS 2 semantics
 
@@ -30,21 +32,50 @@ For QoS 2 messages (`EXACTLY_ONCE`), `ack()` sends PUBREC. The library then hand
 
 ### QoS 2 deduplication during the manual-ack window
 
-Between receiving the initial PUBLISH and calling `ack()`, PUBREC has not been sent, so the broker may retransmit the PUBLISH (e.g. after a reconnect). The library silently drops the duplicate — your application sees the message exactly once regardless of how many retransmissions occur.
+Between receiving the initial PUBLISH and calling `ack()`, PUBREC has not been sent, so the broker may retransmit the PUBLISH. Retransmitted PUBLISH packets for that delivery are ignored while the same connection remains active and the message is still unacknowledged.
 
-## What happens on reconnect before `ack()`
+## Connection loss before `ack()`
 
-- **QoS 1**: the broker retransmits the message after reconnection. Your queue receives it again as a new message with the DUP flag set.
-- **QoS 2**: the library's deduplication logic ensures only one delivery regardless of reconnects.
+Manual acknowledgement alone does not preserve an unacknowledged delivery across reconnects. Broker redelivery requires a stable `client_id` and a persistent session:
 
-## Example: durable job processing
+**MQTT 3.1.1:**
+
+```python
+client = create_client(
+    "localhost",
+    client_id="jobs-worker-1",
+    clean_session=False,
+)
+```
+
+**MQTT 5.0:**
+
+```python
+client = create_client(
+    "localhost",
+    version="5.0",
+    client_id="jobs-worker-1",
+    clean_session=False,
+    session_expiry_interval=3600,
+)
+```
+
+With a persistent broker session, an unacknowledged QoS 1 or QoS 2 message may be delivered again after reconnect. QoS 2 duplicate suppression does not extend across reconnects or process restarts, so do not rely on it for exactly-once execution of application code.
+
+The default connection settings start a clean session, so they do not provide durable redelivery after a connection or process is lost.
+
+## Example: persistent job consumer
 
 ```python
 import asyncio
 from zmqtt import create_client, QoS
 
 async def main():
-    async with create_client("localhost") as client:
+    async with create_client(
+        "localhost",
+        client_id="jobs-worker-1",
+        clean_session=False,
+    ) as client:
         async with client.subscribe(
             "jobs/process",
             qos=QoS.AT_LEAST_ONCE,
@@ -55,7 +86,8 @@ async def main():
                     await process_job(msg.payload)
                     await msg.ack()
                 except Exception:
-                    # Do NOT ack — broker will redeliver
+                    # Leave the delivery unacknowledged. A persistent broker
+                    # session makes it eligible for redelivery.
                     raise
 
 asyncio.run(main())

--- a/docs/advanced/mqtt5.md
+++ b/docs/advanced/mqtt5.md
@@ -72,21 +72,31 @@ async for msg in sub:
 Additional keyword arguments are available on 5.0 connections:
 
 ```python
+from zmqtt import RetainHandling
+
 async with client.subscribe(
     "local/events",
-    no_local=True,          # do not receive own publishes
+    no_local=True,             # do not receive own publishes
     retain_as_published=True,  # preserve the retain flag as published
+    retain_handling=RetainHandling.SEND_IF_NOT_EXISTS,
+    subscription_identifier=7,
 ) as sub:
-    ...
+    async for msg in sub:
+        if msg.properties is not None:
+            print(msg.properties.subscription_identifier)
 ```
 
 | Option | Type | Description |
 |--------|------|-------------|
 | `no_local` | `bool` | Skip messages published by this client |
 | `retain_as_published` | `bool` | Forward the original retain flag, not the delivery flag |
+| `retain_handling` | `RetainHandling` | Control when retained messages are sent for this subscription |
+| `subscription_identifier` | `int \| None` | Ask the broker to identify messages caused by this subscription |
 
 !!! warning
-    `no_local` and `retain_as_published` raise `RuntimeError` when used on a `version="3.1.1"` connection.
+    These options require MQTT 5.0. Using a 5.0-only value on a `version="3.1.1"` connection raises `RuntimeError`. A subscription identifier must be between `1` and `268435455`.
+
+The broker copies `subscription_identifier` into matching PUBLISH packets, where it is available as `msg.properties.subscription_identifier`. This is especially useful when separate subscriptions have overlapping filters.
 
 ## Request / response (`client.request()`)
 

--- a/docs/advanced/request-response.md
+++ b/docs/advanced/request-response.md
@@ -99,12 +99,12 @@ the message.
 ## Timeout
 
 `request()` raises `asyncio.TimeoutError` when no matching reply arrives within
-`timeout` seconds (default `30.0`). The request's reply-topic interest is
-always cleaned up, even on timeout or cancellation.
+`timeout` seconds (default `30.0`). The client stops listening for the matching
+response after return, timeout, or cancellation.
 
-Timed-out requests are removed from the correlation dispatcher immediately.
-A late response is not retained in memory; it is ignored by request routing but
-is still delivered to any regular subscription covering that topic.
+After a timeout, a late response is not retained in memory. It cannot complete
+the expired request, but it is still delivered to any regular subscription
+covering that topic.
 
 ```python
 import asyncio
@@ -115,21 +115,28 @@ except asyncio.TimeoutError:
     print("Service did not respond in time")
 ```
 
+## Connection loss and reconnection
+
+With automatic reconnection enabled (the default), a request that has already been published continues waiting for its matching response. Its response topic is restored after reconnect, and the original `timeout` continues to apply across the interruption.
+
+With reconnection disabled, a request that is already waiting remains pending until its timeout expires. Calling `client.disconnect()` while requests are pending ends them with `MQTTDisconnectedError`.
+
 ## Errors
 
 | Exception               | Raised when                                       |
 | ----------------------- | ------------------------------------------------- |
 | `RuntimeError`          | `request()` is called on an MQTT 3.1.1 connection |
 | `MQTTInvalidTopicError` | `properties.response_topic` contains wildcards    |
-| `MQTTDisconnectedError` | Connection is lost while waiting for the reply    |
+| `MQTTDisconnectedError` | The request cannot start, or `client.disconnect()` is called while it is active |
 | `ValueError`            | Topic/correlation pair is already in use          |
 | `asyncio.TimeoutError`  | No matching reply arrives within `timeout`        |
 
 ## Request backpressure
 
-The client keeps one future per active request and never buffers unmatched or
-late response messages. `max_pending_requests` bounds the number of active
-futures (default `1000`): additional calls wait for capacity before publishing.
+The client keeps one pending result per active request and never buffers
+unmatched or late response messages. `max_pending_requests` bounds the number
+of active requests (default `1000`): additional calls wait for capacity before
+publishing.
 
 ```python
 client = create_client(

--- a/docs/advanced/scaling.md
+++ b/docs/advanced/scaling.md
@@ -34,6 +34,30 @@ async with MQTTClient("broker.example.com") as client:
     await client.publish("jobs/resize", b"image-42.jpg", qos=QoS.AT_LEAST_ONCE)
 ```
 
+## Broker-specific subscription prefixes
+
+Some brokers provide group-less subscription prefixes in addition to the standard `$share/<group>/...` syntax. zmqtt recognises `$queue/...` and `$exclusive/...` by default. The broker removes such a prefix before delivering the message, so a subscription to `$queue/jobs/#` receives messages published to `jobs/#`.
+
+Use `stripped_prefixes` to support another prefix used by your broker. The tuple replaces the defaults, so include any default prefixes you still need:
+
+```python
+client = MQTTClient(
+    "broker.example.com",
+    stripped_prefixes=("$queue", "$exclusive", "$q"),
+)
+```
+
+The public `topic_matches()` helper follows the same rules when matching topics outside an active subscription:
+
+```python
+from zmqtt import topic_matches
+
+assert topic_matches("$queue/jobs/+", "jobs/resize")
+assert topic_matches("$q/jobs/+", "jobs/resize", stripped_prefixes=("$q",))
+```
+
+Do not add namespaces such as `$SYS` to `stripped_prefixes`: brokers publish those topics with the namespace intact.
+
 ## QoS recommendation
 
 Use **QoS 1** (`AT_LEAST_ONCE`) or **QoS 2** (`EXACTLY_ONCE`) for shared subscriptions. With QoS 0 the broker makes no delivery guarantees; if the chosen worker disconnects mid-flight the message is silently dropped. QoS 1 ensures the message is redelivered to another group member on reconnect.
@@ -44,12 +68,13 @@ For strict exactly-once semantics use QoS 2 or handle idempotency at the applica
 
 All brokers supported by zmqtt's test suite accept the `$share/<group>/<topic>` syntax for both MQTT 3.1.1 and 5.0 connections:
 
-| Broker | Supported since | Notes |
-|--------|----------------|-------|
-| Apache ActiveMQ Artemis | 2.16.0 | MQTT 3.1.1 and 5.0 |
-| Eclipse Mosquitto | 2.0.0 | MQTT 3.1.1 and 5.0 |
-| HiveMQ CE | 2021.1 | MQTT 3.1.1 and 5.0 |
-| NanoMQ | 0.6.0 | MQTT 3.1.1 and 5.0; rejects double-slash filters — see note below |
+| Broker | MQTT versions tested | Notes |
+|--------|----------------------|-------|
+| Apache ActiveMQ Artemis | 3.1.1 and 5.0 | Standard `$share/<group>/...` syntax |
+| Eclipse Mosquitto | 3.1.1 and 5.0 | Standard `$share/<group>/...` syntax |
+| EMQX | 3.1.1 and 5.0 | Also tested with group-less `$queue/...` subscriptions |
+| HiveMQ CE | 3.1.1 and 5.0 | Standard `$share/<group>/...` syntax |
+| NanoMQ | 3.1.1 and 5.0 | Rejects double-slash filters — see note below |
 
 > **NanoMQ — avoid double slashes in shared filters**
 >

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -97,6 +97,10 @@
     options:
       show_source: false
 
+::: zmqtt.MQTTSubscribeError
+    options:
+      show_source: false
+
 ::: zmqtt.MQTTInvalidTopicError
     options:
       show_source: false

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -51,6 +51,12 @@
     options:
       show_source: false
 
+## Utilities
+
+::: zmqtt.topic_matches
+    options:
+      show_source: false
+
 ## Enumerations
 
 ::: zmqtt.QoS

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -8,6 +8,7 @@ MQTTError
   ├── MQTTProtocolError     # malformed or unexpected packet
   ├── MQTTDisconnectedError # connection lost unexpectedly
   ├── MQTTTimeoutError      # ping or operation timed out
+  ├── MQTTSubscribeError    # one or more filters rejected by the broker
   └── MQTTInvalidTopicError # topic string failed MQTT validation
 ```
 
@@ -20,6 +21,7 @@ from zmqtt import (
     MQTTProtocolError,
     MQTTDisconnectedError,
     MQTTTimeoutError,
+    MQTTSubscribeError,
     MQTTInvalidTopicError,
 )
 ```
@@ -50,15 +52,32 @@ Common return codes (MQTT 3.1.1):
 | 4 | Bad username or password |
 | 5 | Not authorised |
 
+### `MQTTSubscribeError`
+
+Raised when the broker rejects one or more topic filters in its SUBACK response. This commonly indicates an authorization failure. The `failures` attribute maps each rejected filter to its numeric reason code:
+
+```python
+from zmqtt import MQTTSubscribeError
+
+try:
+    async with client.subscribe("private/#") as sub:
+        ...
+except MQTTSubscribeError as e:
+    for topic_filter, reason_code in e.failures.items():
+        print(f"{topic_filter!r} rejected: 0x{reason_code:02X}")
+```
+
+The same exception is raised by `await sub.start()` when using the manual subscription lifecycle.
+
 ### `MQTTProtocolError`
 
 Raised when the broker sends a packet that violates the MQTT spec — wrong packet type in context, malformed header, etc. This usually indicates a broker bug or a mismatch between library version and broker behaviour.
 
 ### `MQTTDisconnectedError`
 
-Raised when the TCP connection drops unexpectedly (network failure, broker restart, etc.). If reconnection is enabled (the default), this error is caught internally and the client reconnects automatically — your application code never sees it.
+Raised when an operation cannot continue because the connection was lost. If reconnection is enabled (the default), transient connection failures are normally handled automatically.
 
-If reconnection is disabled (`ReconnectConfig(enabled=False)`), `MQTTDisconnectedError` propagates out of `publish()`, `subscribe()`, `ping()`, and through the context manager body.
+If reconnection is disabled (`ReconnectConfig(enabled=False)`), an in-progress or subsequent `publish()`, `ping()`, or subscription start may raise `MQTTDisconnectedError`. The exception is not injected asynchronously into unrelated application code.
 
 ### `MQTTTimeoutError`
 
@@ -137,24 +156,11 @@ See [Request / Response](advanced/request-response.md) for details.
 
 ## Reconnection interaction
 
-When `ReconnectConfig(enabled=True)` (the default), `MQTTDisconnectedError` and `MQTTTimeoutError` inside the protocol loop are suppressed and the client reconnects with exponential backoff. Your `async for msg in sub` loop keeps waiting — it will resume delivering messages once the connection is restored.
+When `ReconnectConfig(enabled=True)` (the default), the client reconnects with exponential backoff. An active `async for msg in sub` loop keeps waiting and resumes after the subscription is restored.
 
-When reconnection is disabled, the exception propagates out of the client context manager's `__aexit__` as an `ExceptionGroup` (Python 3.11+ TaskGroup semantics):
+When reconnection is disabled, an active subscription iterator does not receive an exception by itself; it simply has no new messages to yield. Use application-level cancellation or timeouts when a consumer must stop after connectivity is lost. A later operation that requires a live connection raises `MQTTDisconnectedError`.
 
-```python
-from zmqtt import create_client, ReconnectConfig
-from zmqtt import MQTTDisconnectedError
-
-async with create_client(
-    "localhost",
-    reconnect=ReconnectConfig(enabled=False),
-) as client:
-    try:
-        async for msg in sub:
-            ...
-    except* MQTTDisconnectedError:
-        print("Connection lost, reconnection disabled")
-```
+Pending MQTT 5.0 requests have their own timeout and reconnect behaviour; see [Request / Response](advanced/request-response.md#connection-loss-and-reconnection).
 
 See [Reconnection](advanced/reconnection.md) for full details.
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -6,9 +6,8 @@ zmqtt uses the standard `logging` module with the following logger names:
 
 ```
 zmqtt
-  ├── zmqtt.transport
-  ├── zmqtt.protocol
-  └── zmqtt.client
+  ├── zmqtt.client
+  └── zmqtt.protocol
 ```
 
 Configure any of these with the standard `logging` API.
@@ -32,30 +31,27 @@ logging.getLogger("zmqtt.protocol").setLevel(logging.DEBUG)
 
 ## What DEBUG output looks like
 
-At `DEBUG` level, the protocol layer logs every packet sent and received:
+At `DEBUG` level, the protocol logger reports connection and packet activity. A typical stream contains:
 
 ```
-DEBUG zmqtt.protocol  → CONNECT client_id='' clean_session=True keepalive=60
-DEBUG zmqtt.protocol  ← CONNACK session_present=False return_code=0
-DEBUG zmqtt.protocol  → SUBSCRIBE filters=['sensors/#']
-DEBUG zmqtt.protocol  ← SUBACK return_codes=[0]
-DEBUG zmqtt.protocol  ← PUBLISH topic='sensors/temp' qos=0 retain=False
-DEBUG zmqtt.protocol  → PINGREQ
-DEBUG zmqtt.protocol  ← PINGRESP
-DEBUG zmqtt.protocol  → DISCONNECT
+DEBUG zmqtt.protocol  Connecting
+DEBUG zmqtt.protocol  Sending 27 bytes
+INFO  zmqtt.protocol  Connected
+DEBUG zmqtt.protocol  Sent SUBSCRIBE
+DEBUG zmqtt.protocol  Received PingResp()
 ```
 
 At `INFO` level the client layer logs reconnection events:
 
 ```
-WARNING zmqtt.client  Connection lost, reconnecting in 1.0s
+WARNING zmqtt.client  Connection lost, reconnecting...
 INFO    zmqtt.client  Successfully reconnected
 ```
 
 Duplicate-filter warnings come from `zmqtt.protocol` (see [Subscribing — Duplicate-filter guard](subscribing.md#duplicate-filter-guard)):
 
 ```
-WARNING zmqtt.protocol  Filter 'data/temp' already registered; skipping duplicate
+WARNING zmqtt.protocol  Filter 'data/temp' already subscribed (ignored)
 ```
 
 ---

--- a/docs/subscribing.md
+++ b/docs/subscribing.md
@@ -28,13 +28,12 @@ await sub.stop()
 
 ### Buffering and backpressure
 
-Each `Subscription` buffers incoming messages in an internal queue. The size of this buffer is controlled by the `receive_buffer_size` parameter, see [Backpressure](advanced/backpressure.md)
+Each `Subscription` buffers incoming messages. The size of this buffer is controlled by `receive_buffer_size`; the default is `1000` messages. See [Backpressure](advanced/backpressure.md) for how a full buffer slows message delivery.
 
-If `receive_buffer_size` > 0 - limits the queue to that number of messages.
+- A positive value limits the buffer to that many messages.
+- `0` makes the buffer unbounded.
 
-If `receive_buffer_size` == 0 - (default) → a safe default of 1000 messages is used.
-
-When the buffer is full, message delivery is naturally slowed down (backpressure) instead of growing memory usage indefinitely.
+When a bounded buffer is full, message delivery is naturally slowed down instead of allowing memory usage to grow indefinitely.
 
 ## Async iterator
 

--- a/src/zmqtt/_internal/protocol.py
+++ b/src/zmqtt/_internal/protocol.py
@@ -43,7 +43,7 @@ from zmqtt.errors import (
     MQTTTimeoutError,
 )
 
-log = logging.getLogger(__name__)
+log = logging.getLogger("zmqtt.protocol")
 
 
 class _SubscriptionGuard:

--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -609,7 +609,8 @@ class MQTTClient:
         Raises:
             RuntimeError: If the client is not using MQTT 5.0.
             MQTTInvalidTopicError: If ``properties.response_topic`` contains wildcards.
-            MQTTDisconnectedError: If the connection is lost while waiting.
+            MQTTDisconnectedError: If the request cannot start because the client
+                is disconnected, or the client is stopped while waiting.
             ValueError: If the same response topic and correlation data are
                 already used by another active request.
             asyncio.TimeoutError: If no matching reply arrives within *timeout*

--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -142,6 +142,7 @@ class MQTTClientV5(Protocol):
         no_local: bool = False,
         retain_as_published: bool = False,
         retain_handling: RetainHandling = RetainHandling.SEND_ON_SUBSCRIBE,
+        subscription_identifier: int | None = None,
     ) -> "Subscription": ...
 
     async def auth(self, method: str, data: bytes | None = None) -> None: ...
@@ -525,7 +526,8 @@ class MQTTClient:
             receive_buffer_size: Maximum messages buffered per internal queue.
                 When the buffers are full the read loop stops pulling from the
                 socket, so a slow consumer pushes back on the broker through the
-                TCP window instead of growing memory.
+                TCP window instead of growing memory. ``0`` makes the queues
+                unbounded; the default is ``1000``.
             no_local: Do not receive messages published by this client (MQTT 5.0
                 only).
             retain_as_published: Preserve the retain flag on forwarded messages


### PR DESCRIPTION

- [x] Tests were added or updated when behavior changed
- [x] Documentation was updated when the public API changed
- [x] The PR title follows Conventional Commits, for example `feat(client): add reconnect timeout`
