### PR TITLE
refactor: More explicit routing logic for responses and regular subscriptions

### DIFF
--- a/src/zmqtt/_internal/protocol.py
+++ b/src/zmqtt/_internal/protocol.py
@@ -23,6 +23,7 @@ from zmqtt._internal.packets.subscribe import (
     UnsubAck,
     Unsubscribe,
 )
+from zmqtt._internal.routing import InboundRecipient, RequestRouter
 from zmqtt._internal.state import (
     InboundQoS2Flight,
     InboundQoS2State,
@@ -115,7 +116,7 @@ class MQTTProtocol:
         connect_timeout: float = 30.0,
         version: Literal["3.1.1", "5.0"] = "3.1.1",
         stripped_prefixes: tuple[str, ...] = topic_matching._DEFAULT_STRIPPED_PREFIXES,
-        response_observer: Callable[[Message], None] | None = None,
+        request_router: RequestRouter | None = None,
     ) -> None:
         self._transport = transport
         self._state = state
@@ -124,7 +125,7 @@ class MQTTProtocol:
         self._connect_timeout = connect_timeout
         self._version: Final = version
         self._stripped_prefixes = stripped_prefixes
-        self._response_observer = response_observer
+        self._request_router = request_router
         self._buf = PacketBuffer(version=version)
         self._ping_waiters: list[asyncio.Future[None]] = []
         self._subscription_guards = _SubscriptionGuards()
@@ -356,7 +357,7 @@ class MQTTProtocol:
         return unsuback
 
     async def add_response_observer(self, topic: str) -> None:
-        """Keep an exact response topic subscribed without claiming its messages."""
+        """Keep an exact response topic subscribed for pending requests."""
         async with self._subscription_guards.hold([topic]):
             await self._add_response_observer(topic)
 
@@ -523,14 +524,40 @@ class MQTTProtocol:
             identifier=identifier,
         )
 
-    def _should_auto_ack(self, publish: Publish) -> bool:
-        """Return True if the subscription selected for this PUBLISH uses auto-ack."""
+    def _select_recipient(self, publish: Publish) -> InboundRecipient:
+        message = self._make_message(publish)
+        if self._request_router is not None:
+            request = self._request_router.claim(message)
+            if request is not None:
+                return InboundRecipient(
+                    message=message,
+                    request=request,
+                )
+
         selection = self._select_subscription(publish)
-        return selection.recipient is None or selection.recipient[1].auto_ack
+        if selection.identifier_missing:
+            identifier = publish.properties.subscription_identifier if publish.properties else None
+            log.warning(
+                "No subscription with identifier %r for topic %r, falling back to filter matching",
+                identifier,
+                publish.topic,
+            )
+        if selection.tied_filters:
+            log.warning(
+                "Multiple equally-specific subscribers for %r: %s, delivering to first",
+                publish.topic,
+                list(selection.tied_filters),
+            )
+        if selection.recipient is None:
+            log.warning("No subscriber for topic %r", publish.topic)
+        return InboundRecipient(
+            message=message,
+            subscription=selection.recipient,
+        )
 
     async def _handle_publish(self, packet: Publish) -> None:
         if packet.qos is QoS.AT_MOST_ONCE:
-            return await self._deliver(packet, ack_callback=None)
+            return await self._deliver(self._select_recipient(packet), ack_callback=None)
         if packet.qos is QoS.AT_LEAST_ONCE:
             return await self._handle_qos1_publish(packet)
         if packet.qos is QoS.EXACTLY_ONCE:
@@ -541,9 +568,10 @@ class MQTTProtocol:
         if packet.packet_id is None:
             msg = "Cannot publish without packet id"
             raise ValueError(msg)
-        if self._should_auto_ack(packet):
+        recipient = self._select_recipient(packet)
+        if recipient.auto_ack:
             await self._send(self._encode(PubAck(packet_id=packet.packet_id)))
-            await self._deliver(packet, ack_callback=None)
+            await self._deliver(recipient, ack_callback=None)
         else:
             acked = False
 
@@ -554,7 +582,7 @@ class MQTTProtocol:
                 acked = True
                 await self._send(self._encode(PubAck(packet_id=cast("int", packet.packet_id))))
 
-            await self._deliver(packet, ack_callback=_puback)
+            await self._deliver(recipient, ack_callback=_puback)
 
     async def _handle_qos2_publish(self, packet: Publish) -> None:
         if packet.packet_id is None:
@@ -567,10 +595,11 @@ class MQTTProtocol:
         if packet.packet_id in self._state.pending_ack_qos2_in:
             # Duplicate PUBLISH while app hasn't called msg.ack() yet — ignore
             return
-        if self._should_auto_ack(packet):
+        recipient = self._select_recipient(packet)
+        if recipient.auto_ack:
             self._state.inflight_qos2_in[packet.packet_id] = InboundQoS2Flight(
                 packet_id=packet.packet_id,
-                publish=packet,
+                recipient=recipient,
                 state=InboundQoS2State.PENDING_PUBREL,
             )
             await self._send(self._encode(PubRec(packet_id=packet.packet_id)))
@@ -582,12 +611,13 @@ class MQTTProtocol:
                 self._state.pending_ack_qos2_in.discard(pid)
                 self._state.inflight_qos2_in[pid] = InboundQoS2Flight(
                     packet_id=pid,
-                    publish=packet,
+                    recipient=recipient,
                     state=InboundQoS2State.PENDING_PUBREL,
+                    delivered=True,
                 )
                 await self._send(self._encode(PubRec(packet_id=pid)))
 
-            await self._deliver(packet, ack_callback=_pubrec)
+            await self._deliver(recipient, ack_callback=_pubrec)
 
     async def _handle_pubrel(self, packet: PubRel) -> None:
         flight = self._state.inflight_qos2_in.pop(packet.packet_id, None)
@@ -595,7 +625,8 @@ class MQTTProtocol:
             msg = f"PUBREL for unknown packet_id {packet.packet_id}"
             raise MQTTProtocolError(msg)
         await self._send(self._encode(PubComp(packet_id=packet.packet_id)))
-        await self._deliver(flight.publish, ack_callback=None)
+        if not flight.delivered:
+            await self._deliver(flight.recipient, ack_callback=None)
 
     async def _handle_puback(self, packet: PubAck) -> None:
         flight = self._state.inflight_qos1.pop(packet.packet_id, None)
@@ -664,33 +695,26 @@ class MQTTProtocol:
 
     async def _deliver(
         self,
-        publish: Publish,
+        recipient: InboundRecipient,
         ack_callback: Callable[[], Awaitable[None]] | None,
     ) -> None:
-        selection = self._select_subscription(publish)
-        has_response_observer = self._state.subscriptions.has_response_observer(publish.topic)
-        if has_response_observer and self._response_observer is not None:
-            self._response_observer(self._make_message(publish))
-        if selection.identifier_missing:
-            identifier = publish.properties.subscription_identifier if publish.properties else None
-            log.warning(
-                "No subscription with identifier %r for topic %r, falling back to filter matching",
-                identifier,
-                publish.topic,
-            )
-        if selection.tied_filters:
-            log.warning(
-                "Multiple equally-specific subscribers for %r: %s, delivering to first",
-                publish.topic,
-                list(selection.tied_filters),
-            )
-
-        recipient = selection.recipient
-        if recipient is None:
-            if not has_response_observer:
-                log.warning("No subscriber for topic %r", publish.topic)
+        if recipient.request is not None:
+            recipient.request.deliver()
             return
-        await self._put_message(publish, [recipient], ack_callback)
+
+        subscription = recipient.subscription
+        if subscription is None:
+            return
+
+        filter_, entry = subscription
+        message = recipient.message
+        if not entry.auto_ack and ack_callback is not None:
+            message._ack_callback = ack_callback
+        await entry.queue.put(message)
+        log.debug(
+            "Delivered message",
+            extra={"topic": message.topic, "filter": filter_},
+        )
 
     def _make_message(self, publish: Publish) -> Message:
         return Message(
@@ -700,19 +724,3 @@ class MQTTProtocol:
             retain=publish.retain,
             properties=publish.properties,
         )
-
-    async def _put_message(
-        self,
-        publish: Publish,
-        recipients: list[tuple[str, SubscriptionEntry]],
-        ack_callback: Callable[[], Awaitable[None]] | None,
-    ) -> None:
-        for filter_, entry in recipients:
-            msg = self._make_message(publish)
-            if not entry.auto_ack and ack_callback is not None:
-                msg._ack_callback = ack_callback
-            await entry.queue.put(msg)
-            log.debug(
-                "Delivered message",
-                extra={"topic": publish.topic, "filter": filter_},
-            )

--- a/src/zmqtt/_internal/request_response.py
+++ b/src/zmqtt/_internal/request_response.py
@@ -2,13 +2,18 @@
 
 import asyncio
 from dataclasses import dataclass, field
-from typing import TypeAlias
+from typing import Protocol, TypeAlias
 
-from zmqtt._internal.protocol import MQTTProtocol
 from zmqtt._internal.types.message import Message
 from zmqtt.errors import MQTTDisconnectedError
 
 _RequestKey: TypeAlias = tuple[str, bytes]
+
+
+class _ResponseSubscriptionManager(Protocol):
+    async def add_response_observer(self, topic: str) -> None: ...
+
+    async def remove_response_observer(self, topic: str) -> None: ...
 
 
 @dataclass(slots=True)
@@ -19,13 +24,14 @@ class _PendingRequest:
     _dispatcher: "_RequestDispatcher"
     _key: _RequestKey
     _closed: bool = field(default=False, init=False)
+    claimed: bool = field(default=False, init=False)
 
     async def close(self) -> None:
         if self._closed:
             return
         self._closed = True
         try:
-            await self._dispatcher.unregister(self._key, self.future)
+            await self._dispatcher.unregister(self._key, self)
         finally:
             if self.future.done() and not self.future.cancelled():
                 self.future.exception()
@@ -39,12 +45,26 @@ class _TopicInterest:
     ready: asyncio.Task[None] | None = None
 
 
+@dataclass(slots=True)
+class _ClaimedResponse:
+    """A response reserved for one pending request on one connection."""
+
+    dispatcher: "_RequestDispatcher"
+    pending: _PendingRequest
+    key: _RequestKey
+    message: Message
+    generation: int
+
+    def deliver(self) -> None:
+        self.dispatcher.complete(self)
+
+
 class _RequestDispatcher:
-    """Route responses to request futures without consuming subscription queues.
+    """Route matching responses exclusively to request futures.
 
     Only active waiters are retained. Incoming messages without a matching
-    waiter are never buffered, so late and unsolicited responses cannot grow
-    dispatcher state.
+    waiter are not buffered here and remain available to ordinary subscription
+    routing, so late and unsolicited responses cannot grow dispatcher state.
     """
 
     def __init__(self, max_pending_requests: int) -> None:
@@ -52,17 +72,21 @@ class _RequestDispatcher:
             msg = "max_pending_requests must be positive"
             raise ValueError(msg)
         self._capacity = asyncio.Semaphore(max_pending_requests)
-        self._pending: dict[_RequestKey, asyncio.Future[Message]] = {}
+        self._pending: dict[_RequestKey, _PendingRequest] = {}
         self._topics: dict[str, _TopicInterest] = {}
-        self._protocol: MQTTProtocol | None = None
+        self._protocol: _ResponseSubscriptionManager | None = None
+        self._generation = 0
 
     @property
     def pending_count(self) -> int:
         return len(self._pending)
 
-    def bind(self, protocol: MQTTProtocol) -> None:
+    def bind(self, protocol: _ResponseSubscriptionManager) -> None:
         """Bind the dispatcher to the current connection's protocol engine."""
         self._protocol = protocol
+        self._generation += 1
+        for pending in self._pending.values():
+            pending.claimed = False
         for interest in self._topics.values():
             interest.ready = None
 
@@ -76,7 +100,7 @@ class _RequestDispatcher:
         """Register a bounded response waiter before its request is published."""
         await self._capacity.acquire()
         key = (topic, correlation_data)
-        future: asyncio.Future[Message] | None = None
+        pending: _PendingRequest | None = None
         registered = False
         try:
             self._ensure_unique(key)
@@ -87,48 +111,66 @@ class _RequestDispatcher:
                 interest = _TopicInterest()
                 self._topics[topic] = interest
 
-            future = asyncio.get_running_loop().create_future()
-            self._pending[key] = future
-            interest.refcount += 1
-            await asyncio.shield(self._ensure_topic_ready(topic, interest))
-            registered = True
-            return _PendingRequest(
-                future=future,
+            pending = _PendingRequest(
+                future=asyncio.get_running_loop().create_future(),
                 _dispatcher=self,
                 _key=key,
             )
+            self._pending[key] = pending
+            interest.refcount += 1
+            await asyncio.shield(self._ensure_topic_ready(topic, interest))
+            registered = True
+            return pending
         finally:
             if not registered:
-                if future is None:
+                if pending is None:
                     self._capacity.release()
                 else:
-                    await self.unregister(key, future)
+                    await self.unregister(key, pending)
 
-    def dispatch(self, message: Message) -> None:
-        """Resolve a matching waiter without suppressing normal delivery."""
+    def claim(self, message: Message) -> _ClaimedResponse | None:
+        """Atomically reserve a matching waiter and return the claimed response."""
         properties = message.properties
         if properties is None or properties.correlation_data is None:
-            return
+            return None
 
-        future = self._pending.get((message.topic, properties.correlation_data))
-        if future is not None and not future.done():
-            future.set_result(message)
+        key = (message.topic, properties.correlation_data)
+        pending = self._pending.get(key)
+        if pending is None or pending.claimed or pending.future.done():
+            return None
+        pending.claimed = True
+        return _ClaimedResponse(
+            dispatcher=self,
+            pending=pending,
+            key=key,
+            message=message,
+            generation=self._generation,
+        )
+
+    def complete(self, response: _ClaimedResponse) -> None:
+        """Deliver a claimed response if it still belongs to this connection."""
+        if (
+            self._generation == response.generation
+            and self._pending.get(response.key) is response.pending
+            and not response.pending.future.done()
+        ):
+            response.pending.future.set_result(response.message)
 
     async def unregister(
         self,
         key: _RequestKey,
-        future: asyncio.Future[Message],
+        pending: _PendingRequest,
     ) -> None:
         """Remove one waiter and release its response-topic interest."""
         removed = False
         try:
-            if self._pending.get(key) is not future:
+            if self._pending.get(key) is not pending:
                 return
 
             removed = True
             del self._pending[key]
-            if not future.done():
-                future.cancel()
+            if not pending.future.done():
+                pending.future.cancel()
 
             topic = key[0]
             interest = self._topics[topic]
@@ -161,9 +203,10 @@ class _RequestDispatcher:
         self._pending.clear()
         self._topics.clear()
         self._protocol = None
-        for future in pending:
-            if not future.done():
-                future.set_exception(MQTTDisconnectedError("Client disconnected"))
+        self._generation += 1
+        for request in pending:
+            if not request.future.done():
+                request.future.set_exception(MQTTDisconnectedError("Client disconnected"))
             self._capacity.release()
         for task in ready_tasks:
             task.cancel()
@@ -177,7 +220,7 @@ class _RequestDispatcher:
             interest.ready = ready
         return ready
 
-    def _require_protocol(self) -> MQTTProtocol:
+    def _require_protocol(self) -> _ResponseSubscriptionManager:
         if self._protocol is None:
             msg = "Not connected"
             raise MQTTDisconnectedError(msg)

--- a/src/zmqtt/_internal/routing.py
+++ b/src/zmqtt/_internal/routing.py
@@ -1,0 +1,32 @@
+"""Application routing contracts for incoming MQTT messages."""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from zmqtt._internal.subscription_index import SubscriptionEntry
+from zmqtt._internal.types.message import Message
+
+
+class RequestClaim(Protocol):
+    """An exclusively claimed request response awaiting delivery."""
+
+    def deliver(self) -> None: ...
+
+
+class RequestRouter(Protocol):
+    """Select a pending request as the recipient for a message."""
+
+    def claim(self, message: Message) -> RequestClaim | None: ...
+
+
+@dataclass(slots=True)
+class InboundRecipient:
+    """The single application recipient selected for an incoming PUBLISH."""
+
+    message: Message
+    request: RequestClaim | None = None
+    subscription: tuple[str, SubscriptionEntry] | None = None
+
+    @property
+    def auto_ack(self) -> bool:
+        return self.request is not None or self.subscription is None or self.subscription[1].auto_ack

--- a/src/zmqtt/_internal/state.py
+++ b/src/zmqtt/_internal/state.py
@@ -6,6 +6,7 @@ from enum import Enum
 
 from zmqtt._internal.packets.publish import PubAck, PubComp, Publish
 from zmqtt._internal.packets.subscribe import SubAck, UnsubAck
+from zmqtt._internal.routing import InboundRecipient
 from zmqtt._internal.subscription_index import SubscriptionIndex
 
 
@@ -59,8 +60,9 @@ class InboundQoS2State(Enum):
 @dataclass(slots=True)
 class InboundQoS2Flight:
     packet_id: int
-    publish: Publish
+    recipient: InboundRecipient
     state: InboundQoS2State
+    delivered: bool = False
 
 
 class SessionState:

--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -682,7 +682,7 @@ class MQTTClient:
             connect_timeout=self._mqtt_connect_timeout,
             version=self._version,
             stripped_prefixes=self._stripped_prefixes,
-            response_observer=self._request_dispatcher.dispatch,
+            request_router=self._request_dispatcher,
         )
         connect_props = None
         if self._version == "5.0":

--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -705,8 +705,12 @@ class MQTTClient:
         self._protocol = protocol
         self._request_dispatcher.bind(protocol)
 
-    async def _connect_with_retry(self) -> None:
+    async def _connect_with_retry(self, *, wait_before_first_attempt: bool = False) -> None:
         delay = self._reconnect.initial_delay
+        if wait_before_first_attempt:
+            await asyncio.sleep(delay)
+            delay = min(delay * self._reconnect.backoff_factor, self._reconnect.max_delay)
+
         attempt = 0
         while True:
             try:
@@ -755,7 +759,7 @@ class MQTTClient:
 
             subs_to_restore = list(self._subscriptions)
             log.warning("Connection lost, reconnecting...")
-            await self._connect_with_retry()
+            await self._connect_with_retry(wait_before_first_attempt=True)
             log.info("Successfully reconnected")
 
 

--- a/tests/test_brokers/_base.py
+++ b/tests/test_brokers/_base.py
@@ -541,7 +541,12 @@ class BrokerTestBase(abc.ABC):
         assert first.payload == b"reply-first"
         assert second.payload == b"reply-second"
 
-    async def test_request_response_does_not_steal_from_regular_subscription(self, topic: str) -> None:
+    @pytest.mark.parametrize("response_qos", tuple(QoS))
+    async def test_matching_response_is_delivered_to_only_one_handler(
+        self,
+        topic: str,
+        response_qos: QoS,
+    ) -> None:
         if self.version != "5.0":
             return
 
@@ -551,77 +556,124 @@ class BrokerTestBase(abc.ABC):
             MQTTClient(self.host, self.port, version=self.version) as requester,
             MQTTClient(self.host, self.port, version=self.version) as responder,
             responder.subscribe(topic) as req_sub,
+            requester.subscribe(response_topic, qos=response_qos) as response_sub,
         ):
-            response_sub = requester.subscribe(response_topic)
-            await response_sub.start()
-
-            async def respond() -> None:
-                msg = await asyncio.wait_for(req_sub.get_message(), timeout=5.0)
-                assert msg.properties is not None
-                await responder.publish(
-                    response_topic,
-                    b"response",
-                    properties=PublishProperties(
-                        correlation_data=msg.properties.correlation_data,
-                    ),
-                )
-
-            responder_task = asyncio.create_task(respond())
-            reply = await requester.request(
-                topic,
-                b"request",
-                properties=PublishProperties(
-                    response_topic=response_topic,
-                    correlation_data=correlation_data,
-                ),
-                timeout=5.0,
-            )
-            regular = await asyncio.wait_for(response_sub.get_message(), timeout=5.0)
-            await responder_task
-
-            # The regular subscription still owns the topic after the
-            # request observer has left.
-            await responder.publish(response_topic, b"ordinary")
-            ordinary = await asyncio.wait_for(response_sub.get_message(), timeout=5.0)
-
-            request_seen = asyncio.Event()
-            send_response = asyncio.Event()
-
-            async def respond_after_regular_subscription_stops() -> None:
-                msg = await asyncio.wait_for(req_sub.get_message(), timeout=5.0)
-                assert msg.properties is not None
-                request_seen.set()
-                await send_response.wait()
-                await responder.publish(
-                    response_topic,
-                    b"response-after-stop",
-                    properties=PublishProperties(
-                        correlation_data=msg.properties.correlation_data,
-                    ),
-                )
-
-            responder_task = asyncio.create_task(respond_after_regular_subscription_stops())
             request_task = asyncio.create_task(
                 requester.request(
                     topic,
-                    b"request-after-stop",
+                    b"request",
                     properties=PublishProperties(
                         response_topic=response_topic,
-                        correlation_data=b"corr-after-stop",
+                        correlation_data=correlation_data,
                     ),
                     timeout=5.0,
                 ),
             )
-            await asyncio.wait_for(request_seen.wait(), timeout=5.0)
-            await response_sub.stop()
-            send_response.set()
-            reply_after_stop = await request_task
-            await responder_task
+            request = await asyncio.wait_for(req_sub.get_message(), timeout=5.0)
+            assert request.properties is not None
+            await responder.publish(
+                response_topic,
+                b"response",
+                properties=PublishProperties(
+                    correlation_data=request.properties.correlation_data,
+                ),
+                qos=response_qos,
+            )
+            reply = await request_task
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(response_sub.get_message(), timeout=0.2)
 
         assert reply.payload == b"response"
-        assert regular.payload == b"response"
-        assert ordinary.payload == b"ordinary"
-        assert reply_after_stop.payload == b"response-after-stop"
+        assert reply.qos is response_qos
+
+    @pytest.mark.parametrize("response_qos", tuple(QoS))
+    async def test_unmatched_response_is_delivered_to_subscription(
+        self,
+        topic: str,
+        response_qos: QoS,
+    ) -> None:
+        if self.version != "5.0":
+            return
+
+        response_topic = topic + "/responses"
+        async with (
+            MQTTClient(self.host, self.port, version=self.version) as requester,
+            MQTTClient(self.host, self.port, version=self.version) as responder,
+            responder.subscribe(topic) as req_sub,
+            requester.subscribe(response_topic, qos=response_qos) as response_sub,
+        ):
+            request_task = asyncio.create_task(
+                requester.request(
+                    topic,
+                    b"request",
+                    properties=PublishProperties(
+                        response_topic=response_topic,
+                        correlation_data=b"request-correlation",
+                    ),
+                    timeout=5.0,
+                ),
+            )
+            request = await asyncio.wait_for(req_sub.get_message(), timeout=5.0)
+            assert request.properties is not None
+            await responder.publish(
+                response_topic,
+                b"unmatched",
+                properties=PublishProperties(
+                    correlation_data=b"unknown-correlation",
+                ),
+                qos=response_qos,
+            )
+            unmatched = await asyncio.wait_for(response_sub.get_message(), timeout=5.0)
+            await responder.publish(
+                response_topic,
+                b"response",
+                properties=PublishProperties(
+                    correlation_data=request.properties.correlation_data,
+                ),
+                qos=response_qos,
+            )
+            reply = await request_task
+
+        assert unmatched.payload == b"unmatched"
+        assert unmatched.qos is response_qos
+        assert reply.payload == b"response"
+
+    async def test_request_survives_regular_subscription_stop(self, topic: str) -> None:
+        if self.version != "5.0":
+            return
+
+        response_topic = topic + "/responses"
+        async with (
+            MQTTClient(self.host, self.port, version=self.version) as requester,
+            MQTTClient(self.host, self.port, version=self.version) as responder,
+            responder.subscribe(topic) as req_sub,
+        ):
+            response_sub = requester.subscribe(response_topic)
+            await response_sub.start()
+            request_task = asyncio.create_task(
+                requester.request(
+                    topic,
+                    b"request",
+                    properties=PublishProperties(
+                        response_topic=response_topic,
+                        correlation_data=b"request-correlation",
+                    ),
+                    timeout=5.0,
+                ),
+            )
+            request = await asyncio.wait_for(req_sub.get_message(), timeout=5.0)
+            assert request.properties is not None
+            await response_sub.stop()
+            await responder.publish(
+                response_topic,
+                b"response-after-stop",
+                properties=PublishProperties(
+                    correlation_data=request.properties.correlation_data,
+                ),
+            )
+            reply = await request_task
+
+        assert reply.payload == b"response-after-stop"
 
     async def test_request_backpressure_delays_publish(self, topic: str) -> None:
         if self.version != "5.0":

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -16,7 +16,7 @@ from zmqtt._internal.packets.codec import encode
 from zmqtt._internal.packets.connect import ConnAck, Connect
 from zmqtt._internal.packets.disconnect import Disconnect
 from zmqtt._internal.packets.properties import PublishProperties
-from zmqtt._internal.packets.publish import PubAck, Publish
+from zmqtt._internal.packets.publish import PubAck, Publish, PubRel
 from zmqtt._internal.packets.reader import PacketBuffer
 from zmqtt._internal.packets.subscribe import SubAck, Subscribe, SubscriptionRequest
 from zmqtt._internal.protocol import (
@@ -65,6 +65,33 @@ class FakeTransport:
     @property
     def is_connected(self) -> bool:
         return not self._closed
+
+
+class FakeRequestClaim:
+    def __init__(self, message: Message, observed: list[Message]) -> None:
+        self._message = message
+        self._observed = observed
+
+    def deliver(self) -> None:
+        self._observed.append(self._message)
+
+
+class FakeRequestRouter:
+    def __init__(
+        self,
+        observed: list[Message],
+        correlation_data: bytes | None = None,
+    ) -> None:
+        self._observed = observed
+        self._correlation_data = correlation_data
+
+    def claim(self, message: Message) -> FakeRequestClaim | None:
+        properties = message.properties
+        if self._correlation_data is not None and (
+            properties is None or properties.correlation_data != self._correlation_data
+        ):
+            return None
+        return FakeRequestClaim(message, self._observed)
 
 
 def make_protocol(
@@ -145,11 +172,12 @@ async def test_ping_timeout_raises() -> None:
 
 
 async def test_deliver_no_match_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
-    """No matching subscription: warning logged, nothing delivered."""
+    """A response-topic interest does not suppress the no-recipient warning."""
     protocol, _ = make_protocol()
+    protocol._state.subscriptions.add_response_observer("unknown/topic")
 
     with caplog.at_level(logging.WARNING, logger="zmqtt.protocol"):
-        await protocol._deliver(
+        await protocol._handle_publish(
             Publish(
                 topic="unknown/topic",
                 payload=b"x",
@@ -157,7 +185,6 @@ async def test_deliver_no_match_logs_warning(caplog: pytest.LogCaptureFixture) -
                 retain=False,
                 dup=False,
             ),
-            ack_callback=None,
         )
 
     assert "unknown/topic" in caplog.text
@@ -176,7 +203,7 @@ async def test_stripped_prefix_filter_receives_messages() -> None:
     )
     protocol._state.subscriptions.add("$queue/sensors/+/state", entry)
 
-    await protocol._deliver(
+    await protocol._handle_publish(
         Publish(
             topic="sensors/dev-1/state",
             payload=b"x",
@@ -184,7 +211,6 @@ async def test_stripped_prefix_filter_receives_messages() -> None:
             retain=False,
             dup=False,
         ),
-        ack_callback=None,
     )
 
     assert entry.queue.qsize() == 1
@@ -257,7 +283,7 @@ async def test_subscription_identifier_routes_delivery() -> None:
     protocol._state.subscriptions.add("demo/+/state", plain)
 
     for echoed, entry in ((1, shared), (2, plain)):
-        await protocol._deliver(
+        await protocol._handle_publish(
             Publish(
                 topic="demo/dev-1/state",
                 payload=b"x",
@@ -266,7 +292,6 @@ async def test_subscription_identifier_routes_delivery() -> None:
                 dup=False,
                 properties=PublishProperties(subscription_identifier=echoed),
             ),
-            ack_callback=None,
         )
         assert entry.queue.qsize() == 1
 
@@ -282,7 +307,7 @@ async def test_unknown_subscription_identifier_falls_back_to_topic_match(
     protocol._state.subscriptions.add("demo/#", entry)
 
     with caplog.at_level(logging.WARNING):
-        await protocol._deliver(
+        await protocol._handle_publish(
             Publish(
                 topic="demo/device/state",
                 payload=b"x",
@@ -291,14 +316,46 @@ async def test_unknown_subscription_identifier_falls_back_to_topic_match(
                 dup=False,
                 properties=PublishProperties(subscription_identifier=999),
             ),
-            ack_callback=None,
         )
 
     assert entry.queue.qsize() == 1
     assert "identifier 999" in caplog.text
 
 
-def test_subscription_identifier_selects_auto_ack_policy() -> None:
+async def test_matching_response_bypasses_regular_subscription() -> None:
+    response_topic = "demo/responses"
+    state = SessionState()
+    observed: list[Message] = []
+
+    protocol = MQTTProtocol(
+        FakeTransport(),
+        state,
+        version="5.0",
+        request_router=FakeRequestRouter(observed, b"expected"),
+    )
+    regular = SubscriptionEntry(queue=asyncio.Queue(), actual_filter=response_topic)
+    state.subscriptions.add(response_topic, regular)
+    state.subscriptions.add_response_observer(response_topic)
+
+    def response(payload: bytes, correlation_data: bytes) -> Publish:
+        return Publish(
+            topic=response_topic,
+            payload=payload,
+            qos=QoS.AT_MOST_ONCE,
+            retain=False,
+            dup=False,
+            properties=PublishProperties(correlation_data=correlation_data),
+        )
+
+    await protocol._handle_publish(response(b"matched", b"expected"))
+    await protocol._handle_publish(response(b"unmatched", b"unknown"))
+
+    assert [message.payload for message in observed] == [b"matched"]
+    assert (await regular.queue.get()).payload == b"unmatched"
+    assert regular.queue.empty()
+
+
+def test_recipient_selects_auto_ack_policy() -> None:
     protocol, _ = make_protocol()
     automatic = SubscriptionEntry(
         queue=asyncio.Queue(),
@@ -326,8 +383,15 @@ def test_subscription_identifier_selects_auto_ack_policy() -> None:
             properties=PublishProperties(subscription_identifier=identifier),
         )
 
-    assert protocol._should_auto_ack(publish(1))
-    assert not protocol._should_auto_ack(publish(2))
+    assert protocol._select_recipient(publish(1)).auto_ack
+    assert not protocol._select_recipient(publish(2)).auto_ack
+
+    response_protocol = MQTTProtocol(
+        FakeTransport(),
+        protocol._state,
+        request_router=FakeRequestRouter([]),
+    )
+    assert response_protocol._select_recipient(publish(2)).auto_ack
 
 
 async def test_multi_filter_subscription_delivers_once_per_publish() -> None:
@@ -349,7 +413,7 @@ async def test_multi_filter_subscription_delivers_once_per_publish() -> None:
         entries[topic_filter] = entry
         protocol._state.subscriptions.add(f"$share/g/{topic_filter}", entry)
 
-    await protocol._deliver(
+    await protocol._handle_publish(
         Publish(
             topic="demo/dev-1/server/state/ack",
             payload=b"x",
@@ -358,7 +422,6 @@ async def test_multi_filter_subscription_delivers_once_per_publish() -> None:
             dup=False,
             properties=PublishProperties(subscription_identifier=1),
         ),
-        ack_callback=None,
     )
     sizes = {f: e.queue.qsize() for f, e in entries.items()}
     assert sum(sizes.values()) == 1  # once per subscription, not once per filter
@@ -501,7 +564,7 @@ async def test_inbound_qos2_manual_ack_duplicate_ignored() -> None:
     )
     transport.feed(encode(publish, version="3.1.1"))
     read_task = await _run_read_loop(protocol)
-    await asyncio.wait_for(queue.get(), timeout=1.0)
+    message = await asyncio.wait_for(queue.get(), timeout=1.0)
 
     # Broker retransmits PUBLISH before app calls ack()
     transport.feed(
@@ -521,5 +584,10 @@ async def test_inbound_qos2_manual_ack_duplicate_ignored() -> None:
 
     assert queue.empty()
     assert transport.sent == []  # no PUBREC for duplicate
+
+    await message.ack()
+    await protocol._handle_pubrel(PubRel(packet_id=11))
+
+    assert queue.empty()
 
     await _stop_task(read_task)

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,6 +1,22 @@
 import pytest
 
 from zmqtt import MQTTClient
+from zmqtt._internal.packets.properties import PublishProperties
+from zmqtt._internal.request_response import _RequestDispatcher
+from zmqtt._internal.types.message import Message
+from zmqtt._internal.types.qos import QoS
+
+
+class FakeResponseSubscriptions:
+    def __init__(self) -> None:
+        self.added: list[str] = []
+        self.removed: list[str] = []
+
+    async def add_response_observer(self, topic: str) -> None:
+        self.added.append(topic)
+
+    async def remove_response_observer(self, topic: str) -> None:
+        self.removed.append(topic)
 
 
 async def test_request_raises_on_v311() -> None:
@@ -12,3 +28,37 @@ async def test_request_raises_on_v311() -> None:
 def test_max_pending_requests_must_be_positive() -> None:
     with pytest.raises(ValueError, match="max_pending_requests"):
         MQTTClient("localhost", max_pending_requests=0)
+
+
+async def test_response_claim_is_exclusive_and_connection_bound() -> None:
+    dispatcher = _RequestDispatcher(max_pending_requests=1)
+    first_connection = FakeResponseSubscriptions()
+    dispatcher.bind(first_connection)
+    pending = await dispatcher.register("responses", b"correlation")
+    message = Message(
+        topic="responses",
+        payload=b"reply",
+        qos=QoS.EXACTLY_ONCE,
+        retain=False,
+        properties=PublishProperties(correlation_data=b"correlation"),
+    )
+
+    stale_response = dispatcher.claim(message)
+    assert stale_response is not None
+    assert dispatcher.claim(message) is None
+
+    second_connection = FakeResponseSubscriptions()
+    dispatcher.bind(second_connection)
+    await dispatcher.restore()
+    current_response = dispatcher.claim(message)
+    assert current_response is not None
+
+    stale_response.deliver()
+    assert not pending.future.done()
+    current_response.deliver()
+    assert await pending.future is message
+
+    await pending.close()
+    assert first_connection.added == ["responses"]
+    assert second_connection.added == ["responses"]
+    assert second_connection.removed == ["responses"]

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -5,6 +5,7 @@ import asyncio
 import pytest
 
 from zmqtt._internal.packets.publish import PubAck, PubComp, Publish
+from zmqtt._internal.routing import InboundRecipient
 from zmqtt._internal.state import (
     InboundQoS2Flight,
     InboundQoS2State,
@@ -15,6 +16,7 @@ from zmqtt._internal.state import (
     SessionState,
 )
 from zmqtt._internal.subscription_index import SubscriptionEntry
+from zmqtt._internal.types.message import Message
 from zmqtt._internal.types.qos import QoS
 
 
@@ -104,20 +106,40 @@ def test_outbound_qos2_initial_state() -> None:
 
 
 def test_inbound_qos2_flight_fields() -> None:
-    publish = Publish(
+    recipient = InboundRecipient(
+        message=Message(
+            topic="t",
+            payload=b"x",
+            qos=QoS.EXACTLY_ONCE,
+            retain=False,
+        ),
+    )
+    flight = InboundQoS2Flight(
+        packet_id=3,
+        recipient=recipient,
+        state=InboundQoS2State.PENDING_PUBREL,
+    )
+    assert flight.state is InboundQoS2State.PENDING_PUBREL
+    assert flight.recipient is recipient
+    assert flight.delivered is False
+
+
+def test_inbound_recipient_uses_subscription_ack_policy() -> None:
+    message = Message(
         topic="t",
         payload=b"x",
         qos=QoS.EXACTLY_ONCE,
         retain=False,
-        dup=False,
-        packet_id=3,
     )
-    flight = InboundQoS2Flight(
-        packet_id=3,
-        publish=publish,
-        state=InboundQoS2State.PENDING_PUBREL,
+    manual = SubscriptionEntry(
+        queue=asyncio.Queue(),
+        auto_ack=False,
     )
-    assert flight.state is InboundQoS2State.PENDING_PUBREL
+    assert not InboundRecipient(
+        message=message,
+        subscription=("t", manual),
+    ).auto_ack
+    assert InboundRecipient(message=message).auto_ack
 
 
 def test_session_state_starts_empty() -> None:


### PR DESCRIPTION
## Summary

- Added `_select_recepient` method to protocol that orchestrates select between request/response and regular subscriptions logic
- Extend edge-cases tests
- fix double delivering edge-cases

## Validation

- [ ] Tests were added or updated when behavior changed
- [ ] Documentation was updated when the public API changed
- [ ] The PR title follows Conventional Commits, for example `feat(client): add reconnect timeout`
