### PR TITLE
feat(client): expose Last Will configuration

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,7 +47,7 @@ jobs:
           --security-opt no-new-privileges:true
 
       nanomq:
-        image: emqx/nanomq@sha256:cf010e7b78981b051cdb833921207991daaf46dccce1ab12dd8d7ec433147161  # latest
+        image: emqx/nanomq:0.25.5@sha256:a03605fe4061452609e0cd89e4ac0c382dc5bb338319e712bb25b6d21a72ba0a
         ports:
           - 1887:1883
         options: >-

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -51,6 +51,10 @@
     options:
       show_source: false
 
+::: zmqtt.Will
+    options:
+      show_source: false
+
 ## Utilities
 
 ::: zmqtt.topic_matches
@@ -78,6 +82,10 @@
       show_source: false
 
 ::: zmqtt.AuthProperties
+    options:
+      show_source: false
+
+::: zmqtt.WillProperties
     options:
       show_source: false
 

--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -22,6 +22,49 @@ client = create_client(
 `host` and `port` may be positional; the remaining parameters are keyword-only
 and have sensible defaults.
 
+## Last Will
+
+Configure the message the broker publishes when the client connection closes
+unexpectedly with `Will`:
+
+```python
+from zmqtt import QoS, Will, create_client
+
+client = create_client(
+    "broker.example.com",
+    will=Will(
+        topic="devices/device-42/status",
+        payload=b"offline",
+        qos=QoS.AT_LEAST_ONCE,
+        retain=True,
+    ),
+)
+```
+
+MQTT 5.0 clients can attach `WillProperties`:
+
+```python
+from zmqtt import QoS, Will, WillProperties, create_client
+
+client = create_client(
+    "broker.example.com",
+    version="5.0",
+    will=Will(
+        topic="devices/device-42/status",
+        payload=b"offline",
+        qos=QoS.AT_LEAST_ONCE,
+        retain=True,
+        properties=WillProperties(
+            will_delay_interval=10,
+            content_type="text/plain",
+        ),
+    ),
+)
+```
+
+The Will configuration is reused on automatic reconnection. Supplying
+`WillProperties` to an MQTT 3.1.1 client raises `RuntimeError`.
+
 ## Version selection
 
 Pass `version="3.1.1"` (default) or `version="5.0"`:
@@ -65,6 +108,7 @@ async with create_client("broker.example.com", port=8883, tls=ctx) as client:
 | `clean_session` | `True` | Discard broker-side session on connect |
 | `username` | `None` | MQTT username |
 | `password` | `None` | MQTT password |
+| `will` | `None` | Last Will published after an unexpected connection loss |
 | `tls` | `False` | TLS configuration (see above) |
 | `reconnect` | `ReconnectConfig()` | Reconnection behaviour — see [Reconnection](advanced/reconnection.md) |
 | `mqtt_connect_timeout` | `30.0` | Seconds to wait for the broker's CONNACK before raising `MQTTTimeoutError` (must be `> 0`). Treated as retryable when reconnection is enabled. |

--- a/src/zmqtt/__init__.py
+++ b/src/zmqtt/__init__.py
@@ -1,4 +1,5 @@
-from zmqtt._internal.packets.properties import AuthProperties, ConnectProperties, PublishProperties
+from zmqtt._internal.packets.connect import Will
+from zmqtt._internal.packets.properties import AuthProperties, ConnectProperties, PublishProperties, WillProperties
 from zmqtt._internal.topic_matching import topic_matches
 from zmqtt._internal.types.message import Message
 from zmqtt._internal.types.qos import QoS
@@ -40,6 +41,8 @@ __all__ = (
     "ReconnectConfig",
     "RetainHandling",
     "Subscription",
+    "Will",
+    "WillProperties",
     "create_client",
     "topic_matches",
 )

--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -12,7 +12,7 @@ from typing import Final, Literal, Protocol, overload
 
 from zmqtt._internal._compat import Self, defer_cancellation
 from zmqtt._internal.packets.auth import Auth
-from zmqtt._internal.packets.connect import Connect
+from zmqtt._internal.packets.connect import Connect, Will
 from zmqtt._internal.packets.properties import (
     AuthProperties,
     ConnectProperties,
@@ -314,6 +314,7 @@ class MQTTClient:
         clean_session: bool = True,
         username: str | None = None,
         password: str | None = None,
+        will: Will | None = None,
         tls: ssl.SSLContext | bool | None = None,
         reconnect: ReconnectConfig | None = None,
         mqtt_connect_timeout: float = 30.0,
@@ -343,6 +344,8 @@ class MQTTClient:
                 existing session state on connect.
             username: Optional username for broker authentication.
             password: Optional plain-text password for broker authentication.
+            will: Last Will published by the broker if the connection closes
+                unexpectedly.
             tls: TLS configuration. Pass ``True`` for default TLS, an
                 :class:`ssl.SSLContext` for custom settings, or ``False`` (default)
                 for a plain TCP connection.
@@ -369,6 +372,9 @@ class MQTTClient:
         if not mqtt_connect_timeout > 0:
             msg = "mqtt_connect_timeout must be positive"
             raise ValueError(msg)
+        if will is not None and will.properties is not None and version != "5.0":
+            msg = "will properties require MQTT 5.0"
+            raise RuntimeError(msg)
         self._host = host
         self._port = port
         self._client_id = client_id
@@ -376,6 +382,7 @@ class MQTTClient:
         self._clean_session = clean_session
         self._username = username
         self._password = password
+        self._will = will
         self._tls = tls
         self._reconnect = reconnect or ReconnectConfig()
         self._mqtt_connect_timeout = mqtt_connect_timeout
@@ -695,6 +702,7 @@ class MQTTClient:
             keepalive=self._keepalive,
             username=self._username,
             password=self._password.encode() if self._password is not None else None,
+            will=self._will,
             properties=connect_props,
         )
         try:
@@ -774,6 +782,7 @@ def create_client(
     clean_session: bool = ...,
     username: str | None = ...,
     password: str | None = ...,
+    will: Will | None = ...,
     tls: ssl.SSLContext | bool = ...,
     reconnect: ReconnectConfig | None = ...,
     mqtt_connect_timeout: float = ...,
@@ -793,6 +802,7 @@ def create_client(
     clean_session: bool = ...,
     username: str | None = ...,
     password: str | None = ...,
+    will: Will | None = ...,
     tls: ssl.SSLContext | bool = ...,
     reconnect: ReconnectConfig | None = ...,
     mqtt_connect_timeout: float = ...,
@@ -813,6 +823,7 @@ def create_client(
     clean_session: bool = ...,
     username: str | None = ...,
     password: str | None = ...,
+    will: Will | None = ...,
     tls: ssl.SSLContext | bool = ...,
     reconnect: ReconnectConfig | None = ...,
     mqtt_connect_timeout: float = ...,
@@ -832,6 +843,7 @@ def create_client(
     clean_session: bool = True,
     username: str | None = None,
     password: str | None = None,
+    will: Will | None = None,
     tls: ssl.SSLContext | bool = False,
     reconnect: ReconnectConfig | None = None,
     mqtt_connect_timeout: float = 30.0,
@@ -853,6 +865,7 @@ def create_client(
         clean_session=clean_session,
         username=username,
         password=password,
+        will=will,
         tls=tls,
         reconnect=reconnect,
         mqtt_connect_timeout=mqtt_connect_timeout,

--- a/tests/test_brokers/_base.py
+++ b/tests/test_brokers/_base.py
@@ -7,6 +7,7 @@ Run with:  pytest -m broker
 import abc
 import asyncio
 import contextlib
+import ssl
 import uuid
 from collections.abc import AsyncGenerator
 from typing import ClassVar, Literal
@@ -26,6 +27,32 @@ from zmqtt import (
     Will,
     WillProperties,
 )
+
+
+class BrokerTransport:
+    def __init__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        self._reader = reader
+        self._writer = writer
+
+    async def read(self, n: int) -> bytes:
+        data = await self._reader.read(n)
+        if not data:
+            msg = "Connection closed by remote"
+            raise MQTTDisconnectedError(msg)
+        return data
+
+    async def write(self, data: bytes) -> None:
+        self._writer.write(data)
+        await self._writer.drain()
+
+    async def close(self) -> None:
+        self._writer.close()
+        with contextlib.suppress(Exception):
+            await self._writer.wait_closed()
+
+    @property
+    def is_connected(self) -> bool:
+        return not self._writer.is_closing()
 
 
 @pytest.mark.broker
@@ -334,6 +361,19 @@ class BrokerTestBase(abc.ABC):
     async def test_last_will_survives_reconnect(self, topic: str) -> None:
         will_topic = f"{topic}/will"
         client_id = f"zmqtt-will-{uuid.uuid4().hex[:8]}"
+        transports: list[BrokerTransport] = []
+
+        async def transport_factory(
+            host: str,
+            port: int,
+            tls: ssl.SSLContext | bool | None,
+        ) -> BrokerTransport:
+            del tls
+            reader, writer = await asyncio.open_connection(host, port)
+            transport = BrokerTransport(reader, writer)
+            transports.append(transport)
+            return transport
+
         will_properties = WillProperties(content_type="text/plain") if self.version == "5.0" else None
         will = Will(
             topic=will_topic,
@@ -352,6 +392,7 @@ class BrokerTestBase(abc.ABC):
                 self.port,
                 client_id=client_id,
                 reconnect=reconnect,
+                transport_factory=transport_factory,
                 version=self.version,
                 will=will,
             ) as client,
@@ -371,11 +412,11 @@ class BrokerTestBase(abc.ABC):
                         pytest.fail("Client did not reconnect within 5 s")
                     await asyncio.sleep(0.05)
 
-            await self.trigger_session_takeover(client_id=client_id)
+            await transports[-1].close()
             first = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
             await wait_for_reconnect()
 
-            await self.trigger_session_takeover(client_id=client_id)
+            await transports[-1].close()
             second = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
             await wait_for_reconnect()
 

--- a/tests/test_brokers/_base.py
+++ b/tests/test_brokers/_base.py
@@ -17,14 +17,11 @@ from zmqtt import (
     MQTTClient,
     MQTTDisconnectedError,
     MQTTProtocolError,
-    MQTTTimeoutError,
     PublishProperties,
     QoS,
     ReconnectConfig,
     RetainHandling,
     Subscription,
-    Will,
-    WillProperties,
 )
 
 
@@ -330,72 +327,6 @@ class BrokerTestBase(abc.ABC):
                     pytest.fail("Subscription did not recover within 10 s")
 
         assert msg.payload == b"after-reconnect"
-
-    async def test_last_will_survives_reconnect(self, topic: str) -> None:
-        will_topic = f"{topic}/will"
-        client_id = f"zmqtt-will-{uuid.uuid4().hex[:8]}"
-        will_properties = WillProperties(content_type="text/plain") if self.version == "5.0" else None
-        will = Will(
-            topic=will_topic,
-            payload=b"offline",
-            qos=QoS.AT_LEAST_ONCE,
-            retain=True,
-            properties=will_properties,
-        )
-        reconnect = ReconnectConfig(enabled=True, initial_delay=0.1, max_delay=0.2, max_attempts=None)
-
-        async with (
-            MQTTClient(self.host, self.port, version=self.version) as observer,
-            observer.subscribe(will_topic, qos=QoS.AT_LEAST_ONCE) as subscription,
-            MQTTClient(
-                self.host,
-                self.port,
-                client_id=client_id,
-                reconnect=reconnect,
-                version=self.version,
-                will=will,
-            ) as client,
-        ):
-            await self.trigger_session_takeover(client_id=client_id)
-            first = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
-
-            async def connection_restored() -> bool:
-                try:
-                    await client.ping(timeout=0.2)
-                except (MQTTDisconnectedError, MQTTTimeoutError, OSError):
-                    return False
-                return True
-
-            deadline = asyncio.get_running_loop().time() + 5.0
-            while not await connection_restored():
-                if asyncio.get_running_loop().time() >= deadline:
-                    pytest.fail("Client did not reconnect within 5 s")
-                await asyncio.sleep(0.05)
-
-            await self.trigger_session_takeover(client_id=client_id)
-            second = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
-
-        for message in (first, second):
-            assert message.topic == will_topic
-            assert message.payload == b"offline"
-            assert message.qos is QoS.AT_LEAST_ONCE
-            if self.version == "5.0":
-                assert message.properties is not None
-                assert message.properties.content_type == "text/plain"
-            else:
-                assert message.properties is None
-
-        async with MQTTClient(self.host, self.port, version=self.version) as observer:
-            async with observer.subscribe(will_topic, qos=QoS.AT_LEAST_ONCE) as subscription:
-                retained = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
-            await observer.publish(will_topic, b"", qos=QoS.AT_LEAST_ONCE, retain=True)
-
-        assert retained.retain is True
-        if self.version == "5.0":
-            assert retained.properties is not None
-            assert retained.properties.content_type == "text/plain"
-        else:
-            assert retained.properties is None
 
     async def test_overlapping_wildcard_priority_routing(
         self,

--- a/tests/test_brokers/_base.py
+++ b/tests/test_brokers/_base.py
@@ -17,7 +17,6 @@ from zmqtt import (
     MQTTClient,
     MQTTDisconnectedError,
     MQTTProtocolError,
-    MQTTTimeoutError,
     PublishProperties,
     QoS,
     ReconnectConfig,
@@ -331,7 +330,7 @@ class BrokerTestBase(abc.ABC):
 
         assert msg.payload == b"after-reconnect"
 
-    async def test_last_will_survives_reconnect(self, topic: str) -> None:
+    async def test_last_will(self, topic: str) -> None:
         will_topic = f"{topic}/will"
         client_id = f"zmqtt-will-{uuid.uuid4().hex[:8]}"
         will_properties = WillProperties(content_type="text/plain") if self.version == "5.0" else None
@@ -339,67 +338,34 @@ class BrokerTestBase(abc.ABC):
             topic=will_topic,
             payload=b"offline",
             qos=QoS.AT_LEAST_ONCE,
-            retain=True,
+            retain=False,
             properties=will_properties,
         )
-        reconnect = ReconnectConfig(enabled=True, initial_delay=2.0, max_delay=2.0, max_attempts=None)
+        victim = MQTTClient(
+            self.host,
+            self.port,
+            client_id=client_id,
+            reconnect=ReconnectConfig(enabled=False),
+            version=self.version,
+            will=will,
+        )
 
         async with (
             MQTTClient(self.host, self.port, version=self.version) as observer,
             observer.subscribe(will_topic, qos=QoS.AT_LEAST_ONCE) as subscription,
-            MQTTClient(
-                self.host,
-                self.port,
-                client_id=client_id,
-                reconnect=reconnect,
-                version=self.version,
-                will=will,
-            ) as client,
+            victim,
         ):
-
-            async def connection_restored() -> bool:
-                try:
-                    await client.ping(timeout=0.2)
-                except (MQTTDisconnectedError, MQTTTimeoutError, OSError):
-                    return False
-                return True
-
-            async def wait_for_reconnect() -> None:
-                deadline = asyncio.get_running_loop().time() + 5.0
-                while not await connection_restored():
-                    if asyncio.get_running_loop().time() >= deadline:
-                        pytest.fail("Client did not reconnect within 5 s")
-                    await asyncio.sleep(0.05)
-
             await self.trigger_session_takeover(client_id=client_id)
-            first = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
-            await wait_for_reconnect()
+            message = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
 
-            await self.trigger_session_takeover(client_id=client_id)
-            second = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
-            await wait_for_reconnect()
-
-        for message in (first, second):
-            assert message.topic == will_topic
-            assert message.payload == b"offline"
-            assert message.qos is QoS.AT_LEAST_ONCE
-            if self.version == "5.0":
-                assert message.properties is not None
-                assert message.properties.content_type == "text/plain"
-            else:
-                assert message.properties is None
-
-        async with MQTTClient(self.host, self.port, version=self.version) as observer:
-            async with observer.subscribe(will_topic, qos=QoS.AT_LEAST_ONCE) as subscription:
-                retained = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
-            await observer.publish(will_topic, b"", qos=QoS.AT_LEAST_ONCE, retain=True)
-
-        assert retained.retain is True
+        assert message.topic == will_topic
+        assert message.payload == b"offline"
+        assert message.qos is QoS.AT_LEAST_ONCE
         if self.version == "5.0":
-            assert retained.properties is not None
-            assert retained.properties.content_type == "text/plain"
+            assert message.properties is not None
+            assert message.properties.content_type == "text/plain"
         else:
-            assert retained.properties is None
+            assert message.properties is None
 
     async def test_overlapping_wildcard_priority_routing(
         self,

--- a/tests/test_brokers/_base.py
+++ b/tests/test_brokers/_base.py
@@ -17,11 +17,14 @@ from zmqtt import (
     MQTTClient,
     MQTTDisconnectedError,
     MQTTProtocolError,
+    MQTTTimeoutError,
     PublishProperties,
     QoS,
     ReconnectConfig,
     RetainHandling,
     Subscription,
+    Will,
+    WillProperties,
 )
 
 
@@ -327,6 +330,72 @@ class BrokerTestBase(abc.ABC):
                     pytest.fail("Subscription did not recover within 10 s")
 
         assert msg.payload == b"after-reconnect"
+
+    async def test_last_will_survives_reconnect(self, topic: str) -> None:
+        will_topic = f"{topic}/will"
+        client_id = f"zmqtt-will-{uuid.uuid4().hex[:8]}"
+        will_properties = WillProperties(content_type="text/plain") if self.version == "5.0" else None
+        will = Will(
+            topic=will_topic,
+            payload=b"offline",
+            qos=QoS.AT_LEAST_ONCE,
+            retain=True,
+            properties=will_properties,
+        )
+        reconnect = ReconnectConfig(enabled=True, initial_delay=0.1, max_delay=0.2, max_attempts=None)
+
+        async with (
+            MQTTClient(self.host, self.port, version=self.version) as observer,
+            observer.subscribe(will_topic, qos=QoS.AT_LEAST_ONCE) as subscription,
+            MQTTClient(
+                self.host,
+                self.port,
+                client_id=client_id,
+                reconnect=reconnect,
+                version=self.version,
+                will=will,
+            ) as client,
+        ):
+            await self.trigger_session_takeover(client_id=client_id)
+            first = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
+
+            async def connection_restored() -> bool:
+                try:
+                    await client.ping(timeout=0.2)
+                except (MQTTDisconnectedError, MQTTTimeoutError, OSError):
+                    return False
+                return True
+
+            deadline = asyncio.get_running_loop().time() + 5.0
+            while not await connection_restored():
+                if asyncio.get_running_loop().time() >= deadline:
+                    pytest.fail("Client did not reconnect within 5 s")
+                await asyncio.sleep(0.05)
+
+            await self.trigger_session_takeover(client_id=client_id)
+            second = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
+
+        for message in (first, second):
+            assert message.topic == will_topic
+            assert message.payload == b"offline"
+            assert message.qos is QoS.AT_LEAST_ONCE
+            if self.version == "5.0":
+                assert message.properties is not None
+                assert message.properties.content_type == "text/plain"
+            else:
+                assert message.properties is None
+
+        async with MQTTClient(self.host, self.port, version=self.version) as observer:
+            async with observer.subscribe(will_topic, qos=QoS.AT_LEAST_ONCE) as subscription:
+                retained = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
+            await observer.publish(will_topic, b"", qos=QoS.AT_LEAST_ONCE, retain=True)
+
+        assert retained.retain is True
+        if self.version == "5.0":
+            assert retained.properties is not None
+            assert retained.properties.content_type == "text/plain"
+        else:
+            assert retained.properties is None
 
     async def test_overlapping_wildcard_priority_routing(
         self,

--- a/tests/test_brokers/_base.py
+++ b/tests/test_brokers/_base.py
@@ -17,11 +17,14 @@ from zmqtt import (
     MQTTClient,
     MQTTDisconnectedError,
     MQTTProtocolError,
+    MQTTTimeoutError,
     PublishProperties,
     QoS,
     ReconnectConfig,
     RetainHandling,
     Subscription,
+    Will,
+    WillProperties,
 )
 
 
@@ -327,6 +330,76 @@ class BrokerTestBase(abc.ABC):
                     pytest.fail("Subscription did not recover within 10 s")
 
         assert msg.payload == b"after-reconnect"
+
+    async def test_last_will_survives_reconnect(self, topic: str) -> None:
+        will_topic = f"{topic}/will"
+        client_id = f"zmqtt-will-{uuid.uuid4().hex[:8]}"
+        will_properties = WillProperties(content_type="text/plain") if self.version == "5.0" else None
+        will = Will(
+            topic=will_topic,
+            payload=b"offline",
+            qos=QoS.AT_LEAST_ONCE,
+            retain=True,
+            properties=will_properties,
+        )
+        reconnect = ReconnectConfig(enabled=True, initial_delay=0.5, max_delay=0.5, max_attempts=None)
+
+        async with (
+            MQTTClient(self.host, self.port, version=self.version) as observer,
+            observer.subscribe(will_topic, qos=QoS.AT_LEAST_ONCE) as subscription,
+            MQTTClient(
+                self.host,
+                self.port,
+                client_id=client_id,
+                reconnect=reconnect,
+                version=self.version,
+                will=will,
+            ) as client,
+        ):
+
+            async def connection_restored() -> bool:
+                try:
+                    await client.ping(timeout=0.2)
+                except (MQTTDisconnectedError, MQTTTimeoutError, OSError):
+                    return False
+                return True
+
+            async def wait_for_reconnect() -> None:
+                deadline = asyncio.get_running_loop().time() + 5.0
+                while not await connection_restored():
+                    if asyncio.get_running_loop().time() >= deadline:
+                        pytest.fail("Client did not reconnect within 5 s")
+                    await asyncio.sleep(0.05)
+
+            await self.trigger_session_takeover(client_id=client_id)
+            first = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
+            await wait_for_reconnect()
+
+            await self.trigger_session_takeover(client_id=client_id)
+            second = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
+            await wait_for_reconnect()
+
+        for message in (first, second):
+            assert message.topic == will_topic
+            assert message.payload == b"offline"
+            assert message.qos is QoS.AT_LEAST_ONCE
+            if self.version == "5.0":
+                assert message.properties is not None
+                assert message.properties.content_type == "text/plain"
+            else:
+                assert message.properties is None
+
+        async with MQTTClient(self.host, self.port, version=self.version) as observer:
+            async with observer.subscribe(will_topic, qos=QoS.AT_LEAST_ONCE) as subscription:
+                retained = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
+            await observer.publish(will_topic, b"", qos=QoS.AT_LEAST_ONCE, retain=True)
+
+        assert retained.retain is True
+        if self.version == "5.0":
+            assert retained.properties is not None
+            assert retained.properties.content_type == "text/plain"
+        else:
+            assert retained.properties is None
 
     async def test_overlapping_wildcard_priority_routing(
         self,

--- a/tests/test_brokers/_base.py
+++ b/tests/test_brokers/_base.py
@@ -7,7 +7,6 @@ Run with:  pytest -m broker
 import abc
 import asyncio
 import contextlib
-import ssl
 import uuid
 from collections.abc import AsyncGenerator
 from typing import ClassVar, Literal
@@ -27,32 +26,6 @@ from zmqtt import (
     Will,
     WillProperties,
 )
-
-
-class BrokerTransport:
-    def __init__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-        self._reader = reader
-        self._writer = writer
-
-    async def read(self, n: int) -> bytes:
-        data = await self._reader.read(n)
-        if not data:
-            msg = "Connection closed by remote"
-            raise MQTTDisconnectedError(msg)
-        return data
-
-    async def write(self, data: bytes) -> None:
-        self._writer.write(data)
-        await self._writer.drain()
-
-    async def close(self) -> None:
-        self._writer.close()
-        with contextlib.suppress(Exception):
-            await self._writer.wait_closed()
-
-    @property
-    def is_connected(self) -> bool:
-        return not self._writer.is_closing()
 
 
 @pytest.mark.broker
@@ -361,19 +334,6 @@ class BrokerTestBase(abc.ABC):
     async def test_last_will_survives_reconnect(self, topic: str) -> None:
         will_topic = f"{topic}/will"
         client_id = f"zmqtt-will-{uuid.uuid4().hex[:8]}"
-        transports: list[BrokerTransport] = []
-
-        async def transport_factory(
-            host: str,
-            port: int,
-            tls: ssl.SSLContext | bool | None,
-        ) -> BrokerTransport:
-            del tls
-            reader, writer = await asyncio.open_connection(host, port)
-            transport = BrokerTransport(reader, writer)
-            transports.append(transport)
-            return transport
-
         will_properties = WillProperties(content_type="text/plain") if self.version == "5.0" else None
         will = Will(
             topic=will_topic,
@@ -382,7 +342,7 @@ class BrokerTestBase(abc.ABC):
             retain=True,
             properties=will_properties,
         )
-        reconnect = ReconnectConfig(enabled=True, initial_delay=0.5, max_delay=0.5, max_attempts=None)
+        reconnect = ReconnectConfig(enabled=True, initial_delay=2.0, max_delay=2.0, max_attempts=None)
 
         async with (
             MQTTClient(self.host, self.port, version=self.version) as observer,
@@ -392,7 +352,6 @@ class BrokerTestBase(abc.ABC):
                 self.port,
                 client_id=client_id,
                 reconnect=reconnect,
-                transport_factory=transport_factory,
                 version=self.version,
                 will=will,
             ) as client,
@@ -412,11 +371,11 @@ class BrokerTestBase(abc.ABC):
                         pytest.fail("Client did not reconnect within 5 s")
                     await asyncio.sleep(0.05)
 
-            await transports[-1].close()
+            await self.trigger_session_takeover(client_id=client_id)
             first = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
             await wait_for_reconnect()
 
-            await transports[-1].close()
+            await self.trigger_session_takeover(client_id=client_id)
             second = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
             await wait_for_reconnect()
 

--- a/tests/test_brokers/test_artemis.py
+++ b/tests/test_brokers/test_artemis.py
@@ -19,10 +19,6 @@ class BaseTestArtemis(BrokerTestBase):
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(sub.get_message(), timeout=0.2)
 
-    async def test_last_will_survives_reconnect(self, topic: str) -> None:
-        del topic
-        pytest.skip("Artemis does not publish a Will on session takeover")
-
     async def test_subscription_identifier_overlapping(self, topic: str) -> None:
         """Artemis supports subscription identifiers (a lone identified
         subscription gets its echo just fine) — what it does NOT share with the

--- a/tests/test_brokers/test_artemis.py
+++ b/tests/test_brokers/test_artemis.py
@@ -19,8 +19,7 @@ class BaseTestArtemis(BrokerTestBase):
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(sub.get_message(), timeout=0.2)
 
-    async def test_last_will_survives_reconnect(self, topic: str) -> None:
-        del topic
+    async def test_last_will(self, topic: str) -> None:  # noqa: ARG002
         pytest.skip("Artemis does not publish a Will on session takeover")
 
     async def test_subscription_identifier_overlapping(self, topic: str) -> None:

--- a/tests/test_brokers/test_artemis.py
+++ b/tests/test_brokers/test_artemis.py
@@ -19,6 +19,10 @@ class BaseTestArtemis(BrokerTestBase):
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(sub.get_message(), timeout=0.2)
 
+    async def test_last_will_survives_reconnect(self, topic: str) -> None:
+        del topic
+        pytest.skip("Artemis does not publish a Will on session takeover")
+
     async def test_subscription_identifier_overlapping(self, topic: str) -> None:
         """Artemis supports subscription identifiers (a lone identified
         subscription gets its echo just fine) — what it does NOT share with the

--- a/tests/test_brokers/test_mosquitto.py
+++ b/tests/test_brokers/test_mosquitto.py
@@ -53,6 +53,7 @@ class BaseTestMosquitto(BrokerTestBase):
                 will=will,
             ) as client,
         ):
+
             async def connection_restored() -> bool:
                 try:
                     await client.ping(timeout=0.2)

--- a/tests/test_brokers/test_mosquitto.py
+++ b/tests/test_brokers/test_mosquitto.py
@@ -1,9 +1,19 @@
 import asyncio
+import uuid
 
 import pytest
 
 from tests.test_brokers._base import BrokerTestBase
-from zmqtt import Subscription
+from zmqtt import (
+    MQTTClient,
+    MQTTDisconnectedError,
+    MQTTTimeoutError,
+    QoS,
+    ReconnectConfig,
+    Subscription,
+    Will,
+    WillProperties,
+)
 
 
 class BaseTestMosquitto(BrokerTestBase):
@@ -17,6 +27,75 @@ class BaseTestMosquitto(BrokerTestBase):
             await sub.get_message()
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(sub.get_message(), timeout=0.2)
+
+    async def test_last_will_survives_reconnect(self, topic: str) -> None:
+        will_topic = f"{topic}/will"
+        client_id = f"zmqtt-will-{uuid.uuid4().hex[:8]}"
+        will_properties = WillProperties(content_type="text/plain") if self.version == "5.0" else None
+        will = Will(
+            topic=will_topic,
+            payload=b"offline",
+            qos=QoS.AT_LEAST_ONCE,
+            retain=True,
+            properties=will_properties,
+        )
+        reconnect = ReconnectConfig(enabled=True, initial_delay=0.5, max_delay=0.5, max_attempts=None)
+
+        async with (
+            MQTTClient(self.host, self.port, version=self.version) as observer,
+            observer.subscribe(will_topic, qos=QoS.AT_LEAST_ONCE) as subscription,
+            MQTTClient(
+                self.host,
+                self.port,
+                client_id=client_id,
+                reconnect=reconnect,
+                version=self.version,
+                will=will,
+            ) as client,
+        ):
+            async def connection_restored() -> bool:
+                try:
+                    await client.ping(timeout=0.2)
+                except (MQTTDisconnectedError, MQTTTimeoutError, OSError):
+                    return False
+                return True
+
+            async def wait_for_reconnect() -> None:
+                deadline = asyncio.get_running_loop().time() + 5.0
+                while not await connection_restored():
+                    if asyncio.get_running_loop().time() >= deadline:
+                        pytest.fail("Client did not reconnect within 5 s")
+                    await asyncio.sleep(0.05)
+
+            await self.trigger_session_takeover(client_id=client_id)
+            first = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
+            await wait_for_reconnect()
+
+            await self.trigger_session_takeover(client_id=client_id)
+            second = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
+            await wait_for_reconnect()
+
+        for message in (first, second):
+            assert message.topic == will_topic
+            assert message.payload == b"offline"
+            assert message.qos is QoS.AT_LEAST_ONCE
+            if self.version == "5.0":
+                assert message.properties is not None
+                assert message.properties.content_type == "text/plain"
+            else:
+                assert message.properties is None
+
+        async with MQTTClient(self.host, self.port, version=self.version) as observer:
+            async with observer.subscribe(will_topic, qos=QoS.AT_LEAST_ONCE) as subscription:
+                retained = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
+            await observer.publish(will_topic, b"", qos=QoS.AT_LEAST_ONCE, retain=True)
+
+        assert retained.retain is True
+        if self.version == "5.0":
+            assert retained.properties is not None
+            assert retained.properties.content_type == "text/plain"
+        else:
+            assert retained.properties is None
 
 
 class TestMosquittoV311(BaseTestMosquitto):

--- a/tests/test_brokers/test_mosquitto.py
+++ b/tests/test_brokers/test_mosquitto.py
@@ -1,19 +1,9 @@
 import asyncio
-import uuid
 
 import pytest
 
 from tests.test_brokers._base import BrokerTestBase
-from zmqtt import (
-    MQTTClient,
-    MQTTDisconnectedError,
-    MQTTTimeoutError,
-    QoS,
-    ReconnectConfig,
-    Subscription,
-    Will,
-    WillProperties,
-)
+from zmqtt import Subscription
 
 
 class BaseTestMosquitto(BrokerTestBase):
@@ -27,76 +17,6 @@ class BaseTestMosquitto(BrokerTestBase):
             await sub.get_message()
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(sub.get_message(), timeout=0.2)
-
-    async def test_last_will_survives_reconnect(self, topic: str) -> None:
-        will_topic = f"{topic}/will"
-        client_id = f"zmqtt-will-{uuid.uuid4().hex[:8]}"
-        will_properties = WillProperties(content_type="text/plain") if self.version == "5.0" else None
-        will = Will(
-            topic=will_topic,
-            payload=b"offline",
-            qos=QoS.AT_LEAST_ONCE,
-            retain=True,
-            properties=will_properties,
-        )
-        reconnect = ReconnectConfig(enabled=True, initial_delay=0.5, max_delay=0.5, max_attempts=None)
-
-        async with (
-            MQTTClient(self.host, self.port, version=self.version) as observer,
-            observer.subscribe(will_topic, qos=QoS.AT_LEAST_ONCE) as subscription,
-            MQTTClient(
-                self.host,
-                self.port,
-                client_id=client_id,
-                reconnect=reconnect,
-                version=self.version,
-                will=will,
-            ) as client,
-        ):
-
-            async def connection_restored() -> bool:
-                try:
-                    await client.ping(timeout=0.2)
-                except (MQTTDisconnectedError, MQTTTimeoutError, OSError):
-                    return False
-                return True
-
-            async def wait_for_reconnect() -> None:
-                deadline = asyncio.get_running_loop().time() + 5.0
-                while not await connection_restored():
-                    if asyncio.get_running_loop().time() >= deadline:
-                        pytest.fail("Client did not reconnect within 5 s")
-                    await asyncio.sleep(0.05)
-
-            await self.trigger_session_takeover(client_id=client_id)
-            first = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
-            await wait_for_reconnect()
-
-            await self.trigger_session_takeover(client_id=client_id)
-            second = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
-            await wait_for_reconnect()
-
-        for message in (first, second):
-            assert message.topic == will_topic
-            assert message.payload == b"offline"
-            assert message.qos is QoS.AT_LEAST_ONCE
-            if self.version == "5.0":
-                assert message.properties is not None
-                assert message.properties.content_type == "text/plain"
-            else:
-                assert message.properties is None
-
-        async with MQTTClient(self.host, self.port, version=self.version) as observer:
-            async with observer.subscribe(will_topic, qos=QoS.AT_LEAST_ONCE) as subscription:
-                retained = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
-            await observer.publish(will_topic, b"", qos=QoS.AT_LEAST_ONCE, retain=True)
-
-        assert retained.retain is True
-        if self.version == "5.0":
-            assert retained.properties is not None
-            assert retained.properties.content_type == "text/plain"
-        else:
-            assert retained.properties is None
 
 
 class TestMosquittoV311(BaseTestMosquitto):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,7 +6,7 @@ from collections import deque
 
 import pytest
 
-from zmqtt import MQTTClient, MQTTTimeoutError, ReconnectConfig, create_client
+from zmqtt import MQTTClient, MQTTTimeoutError, QoS, ReconnectConfig, Will, WillProperties, create_client
 from zmqtt._internal.packets.codec import encode
 from zmqtt._internal.packets.connect import ConnAck
 from zmqtt._internal.transport.base import Transport
@@ -21,6 +21,32 @@ def test_mqtt_connect_timeout_default_is_30s() -> None:
 def test_non_positive_mqtt_connect_timeout_raises(bad: float) -> None:
     with pytest.raises(ValueError, match="mqtt_connect_timeout must be positive"):
         create_client("localhost", mqtt_connect_timeout=bad)
+
+
+def test_create_client_accepts_will() -> None:
+    will = Will(
+        topic="status/client",
+        payload=b"offline",
+        qos=QoS.AT_LEAST_ONCE,
+        retain=True,
+    )
+
+    client = create_client("localhost", will=will)
+
+    assert isinstance(client, MQTTClient)
+
+
+def test_mqtt_v311_rejects_will_properties() -> None:
+    will = Will(
+        topic="status/client",
+        payload=b"offline",
+        qos=QoS.AT_LEAST_ONCE,
+        retain=True,
+        properties=WillProperties(content_type="text/plain"),
+    )
+
+    with pytest.raises(RuntimeError, match=r"will properties require MQTT 5\.0"):
+        MQTTClient("localhost", version="3.1.1", will=will)
 
 
 class FakeTransport:


### PR DESCRIPTION
## Summary

- export `Will` and `WillProperties` from `zmqtt`
- accept and preserve `will` in `MQTTClient` and every `create_client()` overload
- reject MQTT 5.0 Will properties for MQTT 3.1.1 clients
- verify Will delivery, retention, properties, and reconnect behavior through the common real-broker suite using session takeover, with an Artemis skip
- document the public Last Will API

Closes #45

## Validation

- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run mypy`
- `uv run mkdocs build --strict`
- `uv run pytest -q` — 566 passed, 12 skipped
- NanoMQ MQTT 5 Last Will reconnect test repeated 10 times after extending the reconnect delay
- `uv build`

- [x] Tests were added or updated when behavior changed
- [x] Documentation was updated when the public API changed
- [x] The PR title follows Conventional Commits