### PR TITLE
test(artemis): skip flaky message ordering test

### DIFF
--- a/tests/test_brokers/test_artemis.py
+++ b/tests/test_brokers/test_artemis.py
@@ -19,6 +19,16 @@ class BaseTestArtemis(BrokerTestBase):
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(sub.get_message(), timeout=0.2)
 
+    async def test_message_ordering(
+        self,
+        mqtt_client: MQTTClient,  # noqa: ARG002
+        topic: str,  # noqa: ARG002
+    ) -> None:
+        """Artemis has a race condition that occasionally delivers QoS 1 messages
+        out of order, so this test flakes. Skip it while ordering is broken upstream.
+        """
+        pytest.skip("Artemis breaks message ordering: https://issues.apache.org/jira/browse/ARTEMIS-6191")
+
     async def test_last_will(self, topic: str) -> None:
         """
         Unlike other brokers, Artemis doen`t read other client_id takeover as unexpected reconnect


### PR DESCRIPTION
## Summary

Artemis reorders QoS 1 deliveries under a race condition (https://issues.apache.org/jira/browse/ARTEMIS-6191), so test_message_ordering flakes on both 3.1.1 and 5.0. Skip it while ordering is broken upstream.

Closes #57

## Validation

- [x] The PR title follows Conventional Commits, for example `feat(client): add reconnect timeout`
