### PR TITLE
fix: Propagate terminal error to subscription

### DIFF
--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -285,8 +285,30 @@ class Subscription:
         await self.__aexit__(None, None, None)
 
     async def get_message(self) -> Message:
-        """Wait for and return the next message from the subscription queue."""
-        return await self._queue.get()
+        """Wait for and return the next message from the subscription queue.
+
+        Raises:
+            Exception: The terminal error that stopped the client run loop.
+        """
+        failure_signal = self._client._subscription_failure
+        if failure_signal is None:
+            return await self._queue.get()
+        if failure_signal.done():
+            raise failure_signal.result()
+
+        message_task = asyncio.create_task(self._queue.get())
+        try:
+            done, _ = await asyncio.wait(
+                (message_task, failure_signal),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if failure_signal in done:
+                raise failure_signal.result()
+            return message_task.result()
+        finally:
+            if not message_task.done():
+                message_task.cancel()
+            await asyncio.gather(message_task, return_exceptions=True)
 
     def __aiter__(self) -> AsyncIterator[Message]:
         """Return self as the async iterator."""
@@ -394,12 +416,24 @@ class MQTTClient:
         self._protocol: MQTTProtocol | None = None
         self._subscriptions: list[Subscription] = []
         self._run_task: asyncio.Task[None] | None = None
+        self._subscription_failure: asyncio.Future[BaseException] | None = None
 
     async def __aenter__(self) -> Self:
         """Connect to the broker and start the background run loop."""
         await self._connect_with_retry()
+        self._subscription_failure = asyncio.get_running_loop().create_future()
         self._run_task = asyncio.create_task(self._run_loop())
+        self._run_task.add_done_callback(self._notify_subscription_failure)
         return self
+
+    def _notify_subscription_failure(self, run_task: asyncio.Task[None]) -> None:
+        """Wake subscription consumers if the client run loop failed."""
+        if run_task.cancelled():
+            return
+        failure = run_task.exception()
+        signal = self._subscription_failure
+        if failure is not None and signal is not None and not signal.done():
+            signal.set_result(failure)
 
     async def __aexit__(self, *exc: object) -> None:
         """Disconnect cleanly and cancel the run loop."""

--- a/tests/test_brokers/_base.py
+++ b/tests/test_brokers/_base.py
@@ -69,6 +69,12 @@ class BrokerTestBase(abc.ABC):
             ):
                 pass
 
+    async def force_tcp_disconnect(self, client: MQTTClient) -> None:
+        """Close the TCP connection without sending MQTT DISCONNECT."""
+        protocol = client._protocol
+        assert protocol is not None
+        await protocol._transport.close()
+
     async def test_ping(self, mqtt_client: MQTTClient) -> None:
         await mqtt_client.ping()
 
@@ -329,6 +335,47 @@ class BrokerTestBase(abc.ABC):
                     pytest.fail("Subscription did not recover within 10 s")
 
         assert msg.payload == b"after-reconnect"
+
+    async def test_subscription_survives_single_allowed_reconnect_attempt(self, topic: str) -> None:
+        client = MQTTClient(
+            self.host,
+            self.port,
+            client_id=f"zmqtt-single-reconnect-{uuid.uuid4().hex[:8]}",
+            reconnect=ReconnectConfig(initial_delay=0.0, max_attempts=1),
+            version=self.version,
+        )
+
+        async with (
+            client,
+            client.subscribe(topic) as subscription,
+            MQTTClient(self.host, self.port, version=self.version) as publisher,
+        ):
+            message_task = asyncio.create_task(anext(subscription))
+            await asyncio.sleep(0)
+
+            await self.force_tcp_disconnect(client)
+            await asyncio.sleep(0.5)
+            await publisher.publish(topic, b"after-single-reconnect")
+            message = await message_task
+
+        assert message.payload == b"after-single-reconnect"
+
+    async def test_tcp_disconnect_wakes_subscription_when_reconnect_disabled(self, topic: str) -> None:
+        client = MQTTClient(
+            self.host,
+            self.port,
+            reconnect=ReconnectConfig(enabled=False),
+            version=self.version,
+        )
+
+        async with client, client.subscribe(topic) as subscription:
+            message_task = asyncio.create_task(anext(subscription))
+            await asyncio.sleep(0)
+
+            await self.force_tcp_disconnect(client)
+
+            with pytest.raises(MQTTDisconnectedError):
+                await asyncio.wait_for(message_task, timeout=5.0)
 
     async def test_last_will(self, topic: str) -> None:
         will_topic = f"{topic}/will"

--- a/tests/test_brokers/test_artemis.py
+++ b/tests/test_brokers/test_artemis.py
@@ -50,7 +50,7 @@ class BaseTestArtemis(BrokerTestBase):
             observer.subscribe(will_topic, qos=QoS.AT_LEAST_ONCE) as subscription,
             victim,
         ):
-            await victim._protocol._transport.close()  # type: ignore[union-attr]
+            await self.force_tcp_disconnect(victim)
             message = await asyncio.wait_for(subscription.get_message(), timeout=5.0)
 
         assert message.topic == will_topic


### PR DESCRIPTION
## Summary

When the main client's attempt to reconnect ultimately fails, zombie subscriptions persist indefinitely. A terminal error is then transmitted to these subscriptions. This significant change necessitates a minor release and subsequently, a FastStream fix.

## Validation

<!-- Which checks did you run? -->

- [ ] Tests were added or updated when behavior changed
- [ ] Documentation was updated when the public API changed
- [ ] The PR title follows Conventional Commits, for example `feat(client): add reconnect timeout`
