### PR TITLE
feat: Add callback for reconnect failing

### DIFF
--- a/docs/advanced/reconnection.md
+++ b/docs/advanced/reconnection.md
@@ -46,6 +46,37 @@ async with create_client(
     ...
 ```
 
+## Handling failed connection recovery
+
+Use `on_connection_recovery_failed` when application code needs to observe that
+a running client cannot restore its connection:
+
+```python
+from zmqtt import ReconnectConfig, create_client
+
+
+async def connection_recovery_failed() -> None:
+    print("MQTT connection could not be restored")
+
+
+async with create_client(
+    "localhost",
+    reconnect=ReconnectConfig(max_attempts=5),
+    on_connection_recovery_failed=connection_recovery_failed,
+) as client:
+    ...
+```
+
+The async callback is awaited exactly once after a previously established
+connection cannot be restored. It is not called when the initial connection
+fails or when the client is disconnected cleanly. Initial connection failures
+still propagate from `connect()` or the async context manager entry.
+
+After the callback returns, the client stops reconnecting and the terminal
+connection error is propagated to active subscription iterators. Use the
+callback to notify the component that owns the client lifecycle when it needs
+to take further action.
+
 ## How subscriptions survive reconnect
 
 Each `Subscription` is re-subscribed on the new connection automatically. The local message queue is preserved — messages that arrived before the disconnect are still in the queue and will be delivered to your code. New messages start flowing once the broker confirms the re-subscribe.
@@ -67,7 +98,10 @@ async with create_client(
     ...
 ```
 
-With reconnection disabled, the client stops on the first connection loss. `MQTTDisconnectedError` is raised on the next call to `publish()`, `ping()`, or entering a new `subscribe()` context. An active `async for msg in sub` loop will hang once the connection drops — no further messages are delivered and no exception is raised from the iterator itself.
+With reconnection disabled, the client stops on the first connection loss and
+invokes `on_connection_recovery_failed`, if configured. `MQTTDisconnectedError`
+is raised on the next call to `publish()`, `ping()`, entering a new `subscribe()`
+context, or waiting for a message from an active subscription.
 
 ---
 

--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -111,6 +111,7 @@ async with create_client("broker.example.com", port=8883, tls=ctx) as client:
 | `will` | `None` | Last Will published after an unexpected connection loss |
 | `tls` | `False` | TLS configuration (see above) |
 | `reconnect` | `ReconnectConfig()` | Reconnection behaviour — see [Reconnection](advanced/reconnection.md) |
+| `on_connection_recovery_failed` | `None` | Async callback invoked once when a running connection cannot be restored |
 | `mqtt_connect_timeout` | `30.0` | Seconds to wait for the broker's CONNACK before raising `MQTTTimeoutError` (must be `> 0`). Treated as retryable when reconnection is enabled. |
 | `transport_factory` | `None` | Optional low-level transport override, primarily for testing |
 | `session_expiry_interval` | `0` | MQTT 5.0 session expiry in seconds (ignored on 3.1.1) |

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -158,9 +158,15 @@ See [Request / Response](advanced/request-response.md) for details.
 
 ## Reconnection interaction
 
-When `ReconnectConfig(enabled=True)` (the default), the client reconnects with exponential backoff. An active `async for msg in sub` loop keeps waiting and resumes after the subscription is restored.
+When `ReconnectConfig(enabled=True)` (the default), the client reconnects with
+exponential backoff. An active `async for msg in sub` loop keeps waiting and
+resumes after the subscription is restored. If all attempts fail, the optional
+`on_connection_recovery_failed` callback is invoked once and active subscription
+iterators raise the terminal connection error.
 
-When reconnection is disabled, an active subscription iterator does not receive an exception by itself; it simply has no new messages to yield. Use application-level cancellation or timeouts when a consumer must stop after connectivity is lost. A later operation that requires a live connection raises `MQTTDisconnectedError`.
+When reconnection is disabled, active subscription iterators raise
+`MQTTDisconnectedError` after connectivity is lost. A later operation that
+requires a live connection raises the same error.
 
 Pending MQTT 5.0 requests have their own timeout and reconnect behaviour; see [Request / Response](advanced/request-response.md#connection-loss-and-reconnection).
 

--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -339,6 +339,7 @@ class MQTTClient:
         will: Will | None = None,
         tls: ssl.SSLContext | bool | None = None,
         reconnect: ReconnectConfig | None = None,
+        on_connection_recovery_failed: Callable[[], Awaitable[None]] | None = None,
         mqtt_connect_timeout: float = 30.0,
         transport_factory: TransportFactory | None = None,
         version: Literal["3.1.1", "5.0"] = "3.1.1",
@@ -373,6 +374,9 @@ class MQTTClient:
                 for a plain TCP connection.
             reconnect: Reconnection policy. Defaults to
                 :class:`ReconnectConfig` with exponential back-off enabled.
+            on_connection_recovery_failed: Async callback invoked once when a
+                connection that was established successfully cannot be restored.
+                Initial connection failures and clean disconnects do not invoke it.
             mqtt_connect_timeout: Seconds to wait for the broker's CONNACK during
                 the MQTT CONNECT/CONNACK handshake — distinct from the TCP socket
                 connect — before raising :exc:`MQTTTimeoutError`. Must be positive.
@@ -407,6 +411,7 @@ class MQTTClient:
         self._will = will
         self._tls = tls
         self._reconnect = reconnect or ReconnectConfig()
+        self._on_connection_recovery_failed = on_connection_recovery_failed
         self._mqtt_connect_timeout = mqtt_connect_timeout
         self._transport_factory: TransportFactory = transport_factory or _default_transport_factory
         self._version: Final = version
@@ -792,6 +797,7 @@ class MQTTClient:
 
             except (MQTTDisconnectedError, MQTTTimeoutError):
                 if not self._reconnect.enabled:
+                    await self._notify_connection_recovery_failed()
                     raise
                 # Close the dead transport to release the file descriptor.
                 with contextlib.suppress(Exception):
@@ -801,8 +807,16 @@ class MQTTClient:
 
             subs_to_restore = list(self._subscriptions)
             log.warning("Connection lost, reconnecting...")
-            await self._connect_with_retry(wait_before_first_attempt=True)
+            try:
+                await self._connect_with_retry(wait_before_first_attempt=True)
+            except (MQTTConnectError, MQTTTimeoutError, OSError):
+                await self._notify_connection_recovery_failed()
+                raise
             log.info("Successfully reconnected")
+
+    async def _notify_connection_recovery_failed(self) -> None:
+        if self._on_connection_recovery_failed is not None:
+            await self._on_connection_recovery_failed()
 
 
 # No version= argument: defaults to "3.1.1", so the return type is MQTTClientV311.
@@ -819,6 +833,7 @@ def create_client(
     will: Will | None = ...,
     tls: ssl.SSLContext | bool = ...,
     reconnect: ReconnectConfig | None = ...,
+    on_connection_recovery_failed: Callable[[], Awaitable[None]] | None = ...,
     mqtt_connect_timeout: float = ...,
     transport_factory: TransportFactory | None = ...,
     session_expiry_interval: int = ...,
@@ -839,6 +854,7 @@ def create_client(
     will: Will | None = ...,
     tls: ssl.SSLContext | bool = ...,
     reconnect: ReconnectConfig | None = ...,
+    on_connection_recovery_failed: Callable[[], Awaitable[None]] | None = ...,
     mqtt_connect_timeout: float = ...,
     transport_factory: TransportFactory | None = ...,
     session_expiry_interval: int = ...,
@@ -860,6 +876,7 @@ def create_client(
     will: Will | None = ...,
     tls: ssl.SSLContext | bool = ...,
     reconnect: ReconnectConfig | None = ...,
+    on_connection_recovery_failed: Callable[[], Awaitable[None]] | None = ...,
     mqtt_connect_timeout: float = ...,
     transport_factory: TransportFactory | None = ...,
     session_expiry_interval: int = ...,
@@ -880,6 +897,7 @@ def create_client(
     will: Will | None = None,
     tls: ssl.SSLContext | bool = False,
     reconnect: ReconnectConfig | None = None,
+    on_connection_recovery_failed: Callable[[], Awaitable[None]] | None = None,
     mqtt_connect_timeout: float = 30.0,
     transport_factory: TransportFactory | None = None,
     session_expiry_interval: int = 0,
@@ -902,6 +920,7 @@ def create_client(
         will=will,
         tls=tls,
         reconnect=reconnect,
+        on_connection_recovery_failed=on_connection_recovery_failed,
         mqtt_connect_timeout=mqtt_connect_timeout,
         transport_factory=transport_factory,
         version=version,

--- a/tests/test_brokers/_base.py
+++ b/tests/test_brokers/_base.py
@@ -377,6 +377,27 @@ class BrokerTestBase(abc.ABC):
             with pytest.raises(MQTTDisconnectedError):
                 await asyncio.wait_for(message_task, timeout=5.0)
 
+    async def test_on_connection_recovery_failed_called(self) -> None:
+        callback_calls = 0
+
+        async def on_connection_recovery_failed() -> None:
+            nonlocal callback_calls
+            callback_calls += 1
+
+        client = MQTTClient(
+            self.host,
+            self.port,
+            reconnect=ReconnectConfig(enabled=False),
+            on_connection_recovery_failed=on_connection_recovery_failed,
+            version=self.version,
+        )
+
+        async with client:
+            await self.force_tcp_disconnect(client)
+            await asyncio.sleep(0.5)
+
+        assert callback_calls == 1
+
     async def test_last_will(self, topic: str) -> None:
         will_topic = f"{topic}/will"
         client_id = f"zmqtt-will-{uuid.uuid4().hex[:8]}"


### PR DESCRIPTION
## Summary

Provide a callback that executes if the runtime reconnects unsuccessfully.

## Validation

<!-- Which checks did you run? -->

- [ ] Tests were added or updated when behavior changed
- [ ] Documentation was updated when the public API changed
- [ ] The PR title follows Conventional Commits, for example `feat(client): add reconnect timeout`
