### PR TITLE
fix: Accept persistent session deliveries and wait for matching subscription on idle. Fixes #59

### DIFF
--- a/docs/advanced/backpressure.md
+++ b/docs/advanced/backpressure.md
@@ -16,11 +16,10 @@ async with client.subscribe("telemetry/#", receive_buffer_size=100) as sub:
 
 The library's read loop reads packets from the TCP stream and dispatches them. When a `Subscription` queue is full:
 
-1. The relay task that moves messages from the internal protocol queue to your subscription queue blocks on `queue.put()`.
-2. The protocol's internal queue for that filter fills up.
-3. Read loop stops reading new data from the socket.
-4. The TCP receive buffer fills.
-5. The TCP stack signals backpressure to the broker via window size reduction.
+1. The read loop blocks on `queue.put()` to that subscription's queue.
+2. The read loop stops reading new data from the socket.
+3. The TCP receive buffer fills.
+4. The TCP stack signals backpressure to the broker via window size reduction.
 
 The result is bounded client-side memory and flow control back to the broker
 connection. What happens beyond that connection is broker-specific: the broker
@@ -52,7 +51,9 @@ to `1000` and caps the number of concurrent `request()` calls. Additional calls
 wait before publishing, applying backpressure to the caller. Every response is
 routed to a single recipient: a matching response completes only its request.
 An unmatched or late response follows normal routing and may be buffered by at
-most one regular `Subscription`; if none matches, it is discarded.
+most one regular `Subscription`. On a resumed persistent session, a message that
+arrives before its local subscription is declared uses the separate bounded
+[session replay buffer](persistent-sessions.md#startup-replay).
 
 !!! warning
     Applying backpressure affects all topics multiplexed on the same TCP connection. A slow consumer on one `Subscription` will stall delivery to all other subscriptions on the same client. If you need independent flow control per topic, use separate clients or scale your application using shared subscriptions or emqs `$queue`.

--- a/docs/advanced/persistent-sessions.md
+++ b/docs/advanced/persistent-sessions.md
@@ -1,0 +1,135 @@
+# Persistent sessions
+
+A persistent MQTT session keeps broker-side subscriptions and queued messages
+across network connections. It is useful for command consumers that must receive
+QoS 1 or QoS 2 messages published while they are offline.
+
+## Configuration
+
+Use a stable, application-assigned `client_id`. For MQTT 3.1.1, disable clean
+sessions:
+
+```python
+client = create_client(
+    "localhost",
+    client_id="commands-worker-1",
+    clean_session=False,
+)
+```
+
+For MQTT 5.0, also choose a positive session expiry interval:
+
+```python
+client = create_client(
+    "localhost",
+    version="5.0",
+    client_id="commands-worker-1",
+    clean_session=False,
+    session_expiry_interval=3600,
+)
+```
+
+The broker reports whether it resumed an existing session through the CONNACK
+Session Present flag. If no session exists, subscriptions behave like ordinary
+new subscriptions.
+
+## Startup replay
+
+A broker can send queued messages immediately after CONNACK, before application
+code has entered its `client.subscribe(...)` contexts. When Session Present is
+set, zmqtt temporarily holds an incoming message that has no local recipient.
+The message remains unacknowledged at the protocol level.
+
+Whenever a local subscription is declared or restored, zmqtt checks the held
+messages again. Each matching message is moved to that `Subscription` object's
+normal queue and continues through its configured acknowledgement policy:
+
+- with `auto_ack=True`, zmqtt completes the QoS acknowledgement automatically;
+- with `auto_ack=False`, the message remains unacknowledged until `msg.ack()`.
+
+Replay never bypasses `receive_buffer_size`. If the subscription queue fills,
+the remaining messages stay unacknowledged in the replay buffer. Reading from
+the subscription makes room and resumes the transfer, so entering the
+subscription does not wait for the whole offline backlog to fit in its queue.
+
+The first unmatched message starts a replay grace period controlled by
+`session_replay_timeout`, which defaults to 30 seconds. When it ends, zmqtt first
+rechecks every held message and delivers those whose recipient has capacity. It
+then writes one warning and drops anything still held without sending PUBACK or
+PUBREC. Later incoming messages use ordinary routing for the rest of that
+connection: they are delivered when a local recipient exists and otherwise
+acknowledged and dropped.
+
+```python
+client = create_client(
+    "localhost",
+    client_id="commands-worker-1",
+    clean_session=False,
+    session_replay_timeout=60.0,
+)
+```
+
+The timeout is measured from the first buffered message and is not extended by
+later arrivals. It protects the process from retaining replay indefinitely when
+application code never restores the corresponding subscription. Set it high
+enough for the application's normal startup sequence and offline backlog.
+
+Dropping is local only. QoS 1 and QoS 2 exchanges remain incomplete at the
+broker, so their messages can be replayed again after the next resumed
+connection. Until then, those unacknowledged messages may continue occupying
+the broker's in-flight delivery capacity.
+
+If the connection closes before the timeout, the local replay buffer is
+discarded without acknowledgement. The broker remains responsible for replaying
+its QoS 1 and QoS 2 messages on the next resumed connection.
+
+## Subscription declaration order
+
+Held messages are reconsidered after each subscription declaration. The first
+declared subscription selected by normal routing receives the message. Exact
+filters remain more specific than `+`, which remains more specific than `#`,
+among all subscriptions active at that moment.
+
+If several application subscriptions overlap and their declaration order
+matters, declare them from most specific to least specific. MQTT 5 subscription
+identifiers are used when the broker includes them, with the same fallback to
+the currently active filters as ordinary live-message routing.
+
+## Buffer limit
+
+`session_replay_buffer_size` limits how many unmatched replay messages can be
+held per connection. The default is `1000`; `0` makes it unbounded:
+
+```python
+client = create_client(
+    "localhost",
+    client_id="commands-worker-1",
+    clean_session=False,
+    session_replay_buffer_size=5000,
+)
+```
+
+If the limit is exceeded before the replay timeout, zmqtt closes the transport
+and raises `MQTTProtocolError` without acknowledging the overflowing message.
+This is a fail-closed policy: QoS 1 and QoS 2 messages remain in the broker
+session rather than being silently discarded. An unbounded buffer can still
+exhaust process memory during the grace period under a sufficiently high
+message rate.
+
+QoS 0 has no durable redelivery guarantee. It can wait in the in-process replay
+buffer once received, but a disconnect or process failure can still lose it.
+
+## Processing guarantees
+
+Persistent sessions and QoS protect transport delivery, not the side effects of
+application handlers. With automatic acknowledgement, a process failure after
+queueing but before completing business work can still lose that work. With
+manual acknowledgement, a failure before `msg.ack()` causes redelivery and can
+therefore execute a handler more than once.
+
+Use idempotent handlers or application-level deduplication whenever duplicate
+processing is harmful.
+
+---
+
+**See also:** [Manual Ack](manual-ack.md) · [Reconnection](reconnection.md) · [Backpressure](backpressure.md)

--- a/docs/advanced/reconnection.md
+++ b/docs/advanced/reconnection.md
@@ -85,6 +85,8 @@ This preserves the local subscription lifecycle, not every message published
 while the client was offline. Delivery during the gap depends on QoS and the
 broker-side session; durable redelivery requires the persistent-session settings
 described in [Manual Acknowledgement](manual-ack.md#connection-loss-before-ack).
+See [Persistent Sessions](persistent-sessions.md) for startup replay and
+subscription-ordering details.
 
 ## Disabling reconnection
 

--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -115,11 +115,15 @@ async with create_client("broker.example.com", port=8883, tls=ctx) as client:
 | `mqtt_connect_timeout` | `30.0` | Seconds to wait for the broker's CONNACK before raising `MQTTTimeoutError` (must be `> 0`). Treated as retryable when reconnection is enabled. |
 | `transport_factory` | `None` | Optional low-level transport override, primarily for testing |
 | `session_expiry_interval` | `0` | MQTT 5.0 session expiry in seconds (ignored on 3.1.1) |
+| `session_replay_buffer_size` | `1000` | Maximum unmatched messages held while a resumed persistent session waits for local subscriptions; `0` is unbounded |
+| `session_replay_timeout` | `30.0` | Seconds unmatched persistent-session replay may wait before it is dropped locally without acknowledgement |
 | `stripped_prefixes` | `("$queue", "$exclusive")` | Broker subscription prefixes removed before local topic matching; `$share/<group>/` is always supported |
 | `max_pending_requests` | `1000` | Maximum concurrent MQTT 5 `request()` calls; additional calls wait before publishing |
 | `version` | `"3.1.1"` | Protocol version: `"3.1.1"` or `"5.0"` |
 
 See [Reconnection](advanced/reconnection.md) for `ReconnectConfig`,
+[Persistent Sessions](advanced/persistent-sessions.md) for durable broker-side
+sessions and startup replay,
 [Scaling](advanced/scaling.md) for subscription-prefix matching, and
 [Request / Response](advanced/request-response.md) for request concurrency.
 [Error Handling](error-handling.md) covers `MQTTConnectError` on refused

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
   - Advanced:
     - Manual Ack: advanced/manual-ack.md
     - Reconnection: advanced/reconnection.md
+    - Persistent Sessions: advanced/persistent-sessions.md
     - Ping: advanced/ping.md
     - MQTT 5.0: advanced/mqtt5.md
     - Request / Response: advanced/request-response.md

--- a/src/zmqtt/_internal/inbound.py
+++ b/src/zmqtt/_internal/inbound.py
@@ -1,0 +1,509 @@
+"""Inbound PUBLISH routing, acknowledgement, and persistent-session replay."""
+
+import asyncio
+import contextlib
+import logging
+from collections import deque
+from collections.abc import Awaitable, Callable
+from typing import Protocol, TypeAlias, cast
+
+from zmqtt._internal.packets.codec import AnyPacket
+from zmqtt._internal.packets.publish import PubAck, PubComp, Publish, PubRec, PubRel
+from zmqtt._internal.routing import InboundRecipient, RequestRouter
+from zmqtt._internal.state import InboundQoS2Flight, InboundQoS2State, SessionState
+from zmqtt._internal.subscription_index import SubscriptionSelection
+from zmqtt._internal.types.message import Message
+from zmqtt._internal.types.qos import QoS
+from zmqtt.errors import MQTTProtocolError
+
+log = logging.getLogger("zmqtt.protocol")
+
+
+class InboundConnection(Protocol):
+    """Wire operations needed by the inbound publish flow."""
+
+    async def send_packet(self, packet: AnyPacket) -> None: ...
+
+    async def abort(self) -> None: ...
+
+
+class _NoSessionReplay:
+    """Null Object used when the broker did not resume a session."""
+
+    async def accept(
+        self,
+        publish: Publish,
+        recipient: InboundRecipient,
+    ) -> tuple[InboundRecipient, "_ReplayState"]:
+        if recipient.request is None and recipient.subscription is None:
+            log.warning("No subscriber for topic %r", publish.topic)
+        return recipient, self
+
+    async def drain(self, delivery: "InboundPublishFlow") -> "_ReplayState":
+        del delivery
+        return self
+
+    def contains_packet_id(self, packet_id: int) -> bool:
+        del packet_id
+        return False
+
+    def clear(self) -> "_ReplayState":
+        return self
+
+
+class _PersistentReplayIdle:
+    """Persistent session with no messages waiting for a local recipient."""
+
+    def __init__(
+        self,
+        *,
+        buffer_size: int,
+        timeout: float,
+        connection: InboundConnection,
+        owner: "InboundPublishFlow",
+    ) -> None:
+        self._buffer_size = buffer_size
+        self._timeout = timeout
+        self._connection = connection
+        self._owner = owner
+
+    async def accept(
+        self,
+        publish: Publish,
+        recipient: InboundRecipient,
+    ) -> tuple[InboundRecipient | None, "_ReplayState"]:
+        if recipient.request is not None or recipient.subscription is not None:
+            return recipient, self
+
+        buffered = _PersistentReplayBuffered(
+            buffer_size=self._buffer_size,
+            timeout=self._timeout,
+            connection=self._connection,
+            owner=self._owner,
+            idle=self,
+        )
+        return await buffered.accept(publish, recipient)
+
+    async def drain(self, delivery: "InboundPublishFlow") -> "_ReplayState":
+        del delivery
+        return self
+
+    def contains_packet_id(self, packet_id: int) -> bool:
+        del packet_id
+        return False
+
+    def clear(self) -> "_ReplayState":
+        return _NO_SESSION_REPLAY
+
+
+class _PersistentReplayBuffered:
+    """Persistent session with unmatched messages awaiting local subscriptions."""
+
+    def __init__(
+        self,
+        *,
+        buffer_size: int,
+        timeout: float,
+        connection: InboundConnection,
+        owner: "InboundPublishFlow",
+        idle: _PersistentReplayIdle,
+    ) -> None:
+        self._buffer_size = buffer_size
+        self._timeout = timeout
+        self._connection = connection
+        self._owner = owner
+        self._idle = idle
+        self._publishes: deque[Publish] = deque()
+        self._packet_ids: set[int] = set()
+        self._topics: dict[str, int] = {}
+        self._message_count = 0
+        self._delivery_lock = asyncio.Lock()
+        self._expiration_task: asyncio.Task[None] | None = None
+
+    async def accept(
+        self,
+        publish: Publish,
+        recipient: InboundRecipient,
+    ) -> tuple[InboundRecipient | None, "_ReplayState"]:
+        if recipient.request is not None:
+            return recipient, self
+        if recipient.subscription is not None and publish.topic not in self._topics:
+            return recipient, self
+        if publish.packet_id is not None and publish.packet_id in self._packet_ids:
+            return None, self
+        if self._buffer_size and self._message_count >= self._buffer_size:
+            msg = f"Persistent-session replay buffer limit of {self._buffer_size} messages exceeded"
+            await self._connection.abort()
+            raise MQTTProtocolError(msg)
+
+        self._publishes.append(publish)
+        self._message_count += 1
+        self._topics[publish.topic] = self._topics.get(publish.topic, 0) + 1
+        if publish.packet_id is not None:
+            self._packet_ids.add(publish.packet_id)
+        if self._expiration_task is None:
+            self._expiration_task = asyncio.create_task(
+                self._expire_after_timeout(),
+                name="zmqtt-session-replay-expiration",
+            )
+        log.debug("Buffered persistent-session replay for topic %r", publish.topic)
+        return None, self
+
+    async def drain(self, delivery: "InboundPublishFlow") -> "_ReplayState":
+        async with self._delivery_lock:
+            await self._deliver_pending(delivery)
+            if self._message_count:
+                return self
+            self._cancel_expiration()
+            return self._idle
+
+    async def expire(self, delivery: "InboundPublishFlow") -> "_ReplayState":
+        """Deliver newly matched messages, then drop the rest without ACK."""
+        async with self._delivery_lock:
+            await self._deliver_pending(delivery)
+            dropped = self._drop_pending()
+            if dropped:
+                log.warning(
+                    "Dropped %d persistent-session replay messages after %.1f seconds without delivery",
+                    dropped,
+                    self._timeout,
+                )
+                return _NO_SESSION_REPLAY
+            return self._idle
+
+    def contains_packet_id(self, packet_id: int) -> bool:
+        return packet_id in self._packet_ids
+
+    def clear(self) -> "_ReplayState":
+        self._cancel_expiration()
+        self._publishes.clear()
+        self._packet_ids.clear()
+        self._topics.clear()
+        self._message_count = 0
+        return _NO_SESSION_REPLAY
+
+    async def _expire_after_timeout(self) -> None:
+        try:
+            await asyncio.sleep(self._timeout)
+            await self._owner.expire_replay(self)
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            log.exception("Failed to expire persistent-session replay buffer")
+            with contextlib.suppress(Exception):
+                await self._connection.abort()
+        finally:
+            if self._expiration_task is asyncio.current_task():
+                self._expiration_task = None
+
+    def _cancel_expiration(self) -> None:
+        task = self._expiration_task
+        self._expiration_task = None
+        if task is not None and task is not asyncio.current_task():
+            task.cancel()
+
+    async def _deliver_pending(self, delivery: "InboundPublishFlow") -> None:
+        unmatched: deque[Publish] = deque()
+        pending: deque[Publish] = deque()
+        try:
+            while self._publishes:
+                pending = self._publishes
+                self._publishes = deque()
+                while pending:
+                    publish = pending.popleft()
+                    recipient = delivery.select_recipient(publish)
+                    subscription = recipient.subscription
+                    if recipient.request is None and subscription is None:
+                        unmatched.append(publish)
+                        continue
+                    if subscription is not None and subscription[1].queue.full():
+                        unmatched.append(publish)
+                        continue
+                    try:
+                        await delivery.deliver_replay(publish, recipient)
+                    except BaseException:
+                        unmatched.append(publish)
+                        raise
+                    else:
+                        self._discard(publish)
+        finally:
+            unmatched.extend(pending)
+            unmatched.extend(self._publishes)
+            self._publishes = unmatched
+
+    def _drop_pending(self) -> int:
+        dropped = self._message_count
+        self._publishes.clear()
+        self._packet_ids.clear()
+        self._topics.clear()
+        self._message_count = 0
+        return dropped
+
+    def _discard(self, publish: Publish) -> None:
+        self._message_count -= 1
+        topic_count = self._topics[publish.topic] - 1
+        if topic_count:
+            self._topics[publish.topic] = topic_count
+        else:
+            self._topics.pop(publish.topic)
+        if publish.packet_id is not None:
+            self._packet_ids.discard(publish.packet_id)
+
+
+_ReplayState: TypeAlias = _NoSessionReplay | _PersistentReplayIdle | _PersistentReplayBuffered
+_NO_SESSION_REPLAY: _ReplayState = _NoSessionReplay()
+
+
+class InboundPublishFlow:
+    """Own the complete lifecycle of incoming MQTT application messages.
+
+    The flow selects one application recipient, executes inbound QoS handshakes,
+    and holds unmatched messages replayed by a resumed persistent session until
+    a compatible local subscription becomes available. Connection lifecycle,
+    packet decoding, and outbound publishing remain MQTTProtocol concerns.
+    """
+
+    def __init__(
+        self,
+        *,
+        connection: InboundConnection,
+        state: SessionState,
+        request_router: RequestRouter | None,
+        session_replay_buffer_size: int,
+        session_replay_timeout: float,
+    ) -> None:
+        self._connection = connection
+        self._state = state
+        self._request_router = request_router
+        self._session_replay_buffer_size = session_replay_buffer_size
+        self._session_replay_timeout = session_replay_timeout
+        self._replay: _ReplayState = _NO_SESSION_REPLAY
+
+    def begin_session(self, *, session_present: bool) -> None:
+        """Set whether this connection resumed broker-side session state."""
+        self._replay.clear()
+        self._replay = (
+            _PersistentReplayIdle(
+                buffer_size=self._session_replay_buffer_size,
+                timeout=self._session_replay_timeout,
+                connection=self._connection,
+                owner=self,
+            )
+            if session_present
+            else _NO_SESSION_REPLAY
+        )
+
+    def clear(self) -> None:
+        """Discard connection-local replay state without acknowledging it."""
+        self._replay = self._replay.clear()
+
+    async def drain(self) -> None:
+        """Deliver held messages for which a recipient now has capacity."""
+        replay = self._replay
+        next_replay = await replay.drain(self)
+        if self._replay is replay:
+            self._replay = next_replay
+
+    async def expire_replay(self, replay: _PersistentReplayBuffered) -> None:
+        """Expire a buffered state only if it is still active."""
+        if self._replay is not replay:
+            return
+        next_replay = await replay.expire(self)
+        if self._replay is replay:
+            self._replay = next_replay
+
+    async def handle_publish(self, packet: Publish) -> None:
+        """Route one inbound PUBLISH through its QoS receive flow."""
+        if packet.qos is QoS.AT_MOST_ONCE:
+            recipient = await self._select_recipient_or_buffer(packet)
+            if recipient is not None:
+                await self._deliver(recipient, ack_callback=None)
+            return None
+        if packet.qos is QoS.AT_LEAST_ONCE:
+            return await self._handle_qos1_publish(packet)
+        if packet.qos is QoS.EXACTLY_ONCE:
+            return await self._handle_qos2_publish(packet)
+        return None
+
+    async def handle_pubrel(self, packet: PubRel) -> None:
+        """Complete an inbound QoS 2 exchange."""
+        flight = self._state.inflight_qos2_in.pop(packet.packet_id, None)
+        if flight is None:
+            msg = f"PUBREL for unknown packet_id {packet.packet_id}"
+            raise MQTTProtocolError(msg)
+        await self._connection.send_packet(PubComp(packet_id=packet.packet_id))
+        if not flight.delivered:
+            await self._deliver(flight.recipient, ack_callback=None)
+
+    def select_recipient(self, publish: Publish) -> InboundRecipient:
+        """Select the exclusive request or subscription recipient for a PUBLISH."""
+        message = self._make_message(publish)
+        if self._request_router is not None:
+            request = self._request_router.claim(message)
+            if request is not None:
+                return InboundRecipient(
+                    message=message,
+                    request=request,
+                )
+
+        selection = self._select_subscription(publish)
+        if selection.identifier_missing:
+            identifier = publish.properties.subscription_identifier if publish.properties else None
+            log.warning(
+                "No subscription with identifier %r for topic %r, falling back to filter matching",
+                identifier,
+                publish.topic,
+            )
+        if selection.tied_filters:
+            log.warning(
+                "Multiple equally-specific subscribers for %r: %s, delivering to first",
+                publish.topic,
+                list(selection.tied_filters),
+            )
+        return InboundRecipient(
+            message=message,
+            subscription=selection.recipient,
+        )
+
+    def _select_subscription(self, publish: Publish) -> SubscriptionSelection:
+        identifier = publish.properties.subscription_identifier if publish.properties else None
+        if identifier is None:
+            return self._state.subscriptions.select(topic=publish.topic)
+        return self._state.subscriptions.select_by_identifier(
+            topic=publish.topic,
+            identifier=identifier,
+        )
+
+    async def _select_recipient_or_buffer(self, publish: Publish) -> InboundRecipient | None:
+        replay = self._replay
+        selected = self.select_recipient(publish)
+        recipient, next_replay = await replay.accept(publish, selected)
+        if self._replay is replay:
+            self._replay = next_replay
+        return recipient
+
+    async def deliver_replay(
+        self,
+        publish: Publish,
+        recipient: InboundRecipient,
+    ) -> None:
+        """Deliver one message selected by the active replay state."""
+        if publish.qos is QoS.AT_MOST_ONCE:
+            await self._deliver(recipient, ack_callback=None)
+        elif publish.qos is QoS.AT_LEAST_ONCE:
+            await self._deliver_qos1_publish(publish, recipient)
+        elif publish.qos is QoS.EXACTLY_ONCE:
+            await self._accept_qos2_publish(publish, recipient)
+
+    async def _handle_qos1_publish(self, packet: Publish) -> None:
+        if packet.packet_id is None:
+            msg = "Cannot publish without packet id"
+            raise ValueError(msg)
+        if self._replay.contains_packet_id(packet.packet_id):
+            return
+        recipient = await self._select_recipient_or_buffer(packet)
+        if recipient is None:
+            return
+        await self._deliver_qos1_publish(packet, recipient)
+
+    async def _deliver_qos1_publish(
+        self,
+        packet: Publish,
+        recipient: InboundRecipient,
+    ) -> None:
+        if packet.packet_id is None:
+            msg = "Cannot publish without packet id"
+            raise ValueError(msg)
+        if recipient.auto_ack:
+            await self._deliver(recipient, ack_callback=None)
+            await self._connection.send_packet(PubAck(packet_id=packet.packet_id))
+        else:
+            acked = False
+
+            async def _puback() -> None:
+                nonlocal acked
+                if acked:
+                    return
+                acked = True
+                await self._connection.send_packet(PubAck(packet_id=cast("int", packet.packet_id)))
+
+            await self._deliver(recipient, ack_callback=_puback)
+
+    async def _handle_qos2_publish(self, packet: Publish) -> None:
+        if packet.packet_id is None:
+            msg = "Cannot publish without packet id"
+            raise ValueError(msg)
+        if packet.packet_id in self._state.inflight_qos2_in:
+            # PUBREC already sent — resend it (duplicate PUBLISH after PUBREC)
+            await self._connection.send_packet(PubRec(packet_id=packet.packet_id))
+            return
+        if packet.packet_id in self._state.pending_ack_qos2_in:
+            # Duplicate PUBLISH while app hasn't called msg.ack() yet — ignore
+            return
+        if self._replay.contains_packet_id(packet.packet_id):
+            return
+        recipient = await self._select_recipient_or_buffer(packet)
+        if recipient is None:
+            return
+        await self._accept_qos2_publish(packet, recipient)
+
+    async def _accept_qos2_publish(
+        self,
+        packet: Publish,
+        recipient: InboundRecipient,
+    ) -> None:
+        if packet.packet_id is None:
+            msg = "Cannot publish without packet id"
+            raise ValueError(msg)
+        if recipient.auto_ack:
+            self._state.inflight_qos2_in[packet.packet_id] = InboundQoS2Flight(
+                packet_id=packet.packet_id,
+                recipient=recipient,
+                state=InboundQoS2State.PENDING_PUBREL,
+            )
+            await self._connection.send_packet(PubRec(packet_id=packet.packet_id))
+        else:
+            self._state.pending_ack_qos2_in.add(packet.packet_id)
+            pid = packet.packet_id
+
+            async def _pubrec() -> None:
+                self._state.pending_ack_qos2_in.discard(pid)
+                self._state.inflight_qos2_in[pid] = InboundQoS2Flight(
+                    packet_id=pid,
+                    recipient=recipient,
+                    state=InboundQoS2State.PENDING_PUBREL,
+                    delivered=True,
+                )
+                await self._connection.send_packet(PubRec(packet_id=pid))
+
+            await self._deliver(recipient, ack_callback=_pubrec)
+
+    async def _deliver(
+        self,
+        recipient: InboundRecipient,
+        ack_callback: Callable[[], Awaitable[None]] | None,
+    ) -> None:
+        if recipient.request is not None:
+            recipient.request.deliver()
+            return
+
+        subscription = recipient.subscription
+        if subscription is None:
+            return
+
+        filter_, entry = subscription
+        message = recipient.message
+        if not entry.auto_ack and ack_callback is not None:
+            message._ack_callback = ack_callback  # noqa: SLF001 - internal delivery contract
+        await entry.queue.put(message)
+        log.debug("Delivered message for topic %r to filter %r", message.topic, filter_)
+
+    @staticmethod
+    def _make_message(publish: Publish) -> Message:
+        return Message(
+            topic=publish.topic,
+            payload=publish.payload,
+            qos=publish.qos,
+            retain=publish.retain,
+            properties=publish.properties,
+        )

--- a/src/zmqtt/_internal/protocol.py
+++ b/src/zmqtt/_internal/protocol.py
@@ -4,10 +4,11 @@ import asyncio
 import contextlib
 import dataclasses
 import logging
-from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable
-from typing import Final, Literal, cast
+from collections.abc import AsyncGenerator, Iterable
+from typing import Final, Literal
 
 from zmqtt._internal import topic_matching
+from zmqtt._internal.inbound import InboundPublishFlow
 from zmqtt._internal.packets.auth import Auth
 from zmqtt._internal.packets.codec import AnyPacket, encode
 from zmqtt._internal.packets.connect import ConnAck, Connect
@@ -25,14 +26,12 @@ from zmqtt._internal.packets.subscribe import (
 )
 from zmqtt._internal.routing import InboundRecipient, RequestRouter
 from zmqtt._internal.state import (
-    InboundQoS2Flight,
-    InboundQoS2State,
     OutboundQoS2Flight,
     OutboundQoS2State,
     QoS1Flight,
     SessionState,
 )
-from zmqtt._internal.subscription_index import SubscriptionEntry, SubscriptionSelection
+from zmqtt._internal.subscription_index import SubscriptionEntry
 from zmqtt._internal.transport.base import Transport
 from zmqtt._internal.types.message import Message
 from zmqtt._internal.types.qos import QoS
@@ -117,6 +116,8 @@ class MQTTProtocol:
         version: Literal["3.1.1", "5.0"] = "3.1.1",
         stripped_prefixes: tuple[str, ...] = topic_matching._DEFAULT_STRIPPED_PREFIXES,
         request_router: RequestRouter | None = None,
+        session_replay_buffer_size: int = 1000,
+        session_replay_timeout: float = 30.0,
     ) -> None:
         self._transport = transport
         self._state = state
@@ -125,7 +126,13 @@ class MQTTProtocol:
         self._connect_timeout = connect_timeout
         self._version: Final = version
         self._stripped_prefixes = stripped_prefixes
-        self._request_router = request_router
+        self.inbound = InboundPublishFlow(
+            connection=self,
+            state=state,
+            request_router=request_router,
+            session_replay_buffer_size=session_replay_buffer_size,
+            session_replay_timeout=session_replay_timeout,
+        )
         self._buf = PacketBuffer(version=version)
         self._ping_waiters: list[asyncio.Future[None]] = []
         self._subscription_guards = _SubscriptionGuards()
@@ -140,7 +147,7 @@ class MQTTProtocol:
         ``connect_timeout`` seconds the connection is presumed dead and
         ``MQTTTimeoutError`` is raised (mirrors ``ping()``'s PINGRESP timeout).
         """
-        log.debug("Connecting", extra={"client_id": packet.client_id})
+        log.debug("Connecting client %r", packet.client_id)
         await self._send(self._encode(packet))
         try:
             # No asyncio.shield (unlike ping): on timeout the transport is closed and
@@ -160,10 +167,8 @@ class MQTTProtocol:
                     raise MQTTProtocolError(msg)
                 if pkt.return_code != 0:
                     raise MQTTConnectError(pkt.return_code)
-                log.info(
-                    "Connected",
-                    extra={"session_present": pkt.session_present},
-                )
+                log.info("Connected with session_present=%s", pkt.session_present)
+                self.inbound.begin_session(session_present=pkt.session_present)
                 return pkt
 
     async def run(self) -> None:
@@ -210,6 +215,7 @@ class MQTTProtocol:
             if not ping_f.done():
                 ping_f.set_exception(exc)
         self._ping_waiters.clear()
+        self.inbound.clear()
 
     def _ensure_alive(self) -> None:
         """Refuse new operations once the run loop has exited.
@@ -231,7 +237,7 @@ class MQTTProtocol:
         match packet.qos:
             case QoS.AT_MOST_ONCE:
                 await self._send(self._encode(packet))
-                log.debug("Published QoS 0", extra={"topic": packet.topic})
+                log.debug("Published QoS 0 to topic %r", packet.topic)
                 return None
 
             case QoS.AT_LEAST_ONCE:
@@ -245,10 +251,7 @@ class MQTTProtocol:
                     future=future,
                 )
                 await self._send(self._encode(packet))
-                log.debug(
-                    "Published QoS 1",
-                    extra={"topic": packet.topic, "packet_id": pid},
-                )
+                log.debug("Published QoS 1 to topic %r with packet_id=%d", packet.topic, pid)
                 return await future
 
             case QoS.EXACTLY_ONCE:
@@ -263,18 +266,15 @@ class MQTTProtocol:
                     future=future2,
                 )
                 await self._send(self._encode(packet))
-                log.debug(
-                    "Published QoS 2",
-                    extra={"topic": packet.topic, "packet_id": pid},
-                )
+                log.debug("Published QoS 2 to topic %r with packet_id=%d", packet.topic, pid)
                 return await future2
 
     async def subscribe(
         self,
         filters: list[SubscriptionRequest],
         *,
+        queue: asyncio.Queue[Message],
         auto_ack: bool = True,
-        queue_maxsize: int = 0,
         subscription_identifier: int | None = None,
     ) -> tuple[SubAck, dict[str, asyncio.Queue[Message]]]:
         """Send SUBSCRIBE and return (SubAck, {filter: queue}) after broker ACK.
@@ -283,10 +283,9 @@ class MQTTProtocol:
         Duplicate filters (already subscribed) are logged as warnings and skipped;
         they are still included in the SUBSCRIBE packet sent to the broker.
 
-        ``queue_maxsize`` bounds the per-filter delivery queue. When it is full,
-        ``_deliver`` blocks, which stalls the read loop and ultimately pushes back
-        on the broker through the TCP window — the flow-control chain the docs
-        describe. ``0`` keeps the queue unbounded.
+        ``queue`` is shared by all entries in this subscription. When it is full,
+        delivery blocks, which stalls the read loop and ultimately pushes back on
+        the broker through the TCP window.
 
         ``subscription_identifier`` (MQTT 5) is sent in the SUBSCRIBE properties;
         the broker echoes it on every PUBLISH this subscription causes, which lets
@@ -294,19 +293,21 @@ class MQTTProtocol:
         instead of guessing by filter specificity.
         """
         async with self._subscription_guards.hold(req.topic_filter for req in filters):
-            return await self._subscribe(
+            result = await self._subscribe(
                 filters,
                 auto_ack=auto_ack,
-                queue_maxsize=queue_maxsize,
+                queue=queue,
                 subscription_identifier=subscription_identifier,
             )
+        await self.inbound.drain()
+        return result
 
     async def _subscribe(
         self,
         filters: list[SubscriptionRequest],
         *,
         auto_ack: bool,
-        queue_maxsize: int,
+        queue: asyncio.Queue[Message],
         subscription_identifier: int | None,
     ) -> tuple[SubAck, dict[str, asyncio.Queue[Message]]]:
         new_entries: dict[str, SubscriptionEntry] = {}
@@ -317,7 +318,7 @@ class MQTTProtocol:
                 log.warning("Filter %r already subscribed (ignored)", f)
             else:
                 new_entries[f] = SubscriptionEntry(
-                    queue=asyncio.Queue(queue_maxsize),
+                    queue=queue,
                     auto_ack=auto_ack,
                     actual_filter=topic_matching._shared_filter_to_actual(f, self._stripped_prefixes),
                     subscription_identifier=subscription_identifier,
@@ -409,7 +410,7 @@ class MQTTProtocol:
                     Subscribe(packet_id=pid, subscriptions=tuple(filters), properties=properties),
                 ),
             )
-            log.debug("Sent SUBSCRIBE", extra={"packet_id": pid})
+            log.debug("Sent SUBSCRIBE with packet_id=%d", pid)
             suback = await future
             _raise_on_rejected_filters(filters, suback)
             return suback
@@ -430,7 +431,7 @@ class MQTTProtocol:
                     version=self._version,
                 ),
             )
-            log.debug("Sent UNSUBSCRIBE", extra={"packet_id": pid})
+            log.debug("Sent UNSUBSCRIBE with packet_id=%d", pid)
             return await future
         finally:
             self._state.pending_unsubs.pop(pid, None)
@@ -460,10 +461,12 @@ class MQTTProtocol:
                 msg,
             )
         await self._send(self._encode(packet))
-        log.debug("Sent AUTH", extra={"reason_code": packet.reason_code})
+        log.debug("Sent AUTH with reason_code=%d", packet.reason_code)
 
     async def _read_loop(self) -> None:
         while True:
+            for packet in self._buf:
+                await self._dispatch(packet)
             try:
                 data = await self._transport.read(4096)
             except MQTTDisconnectedError:
@@ -471,8 +474,6 @@ class MQTTProtocol:
                     return
                 raise
             self._buf.feed(data)
-            for packet in self._buf:
-                await self._dispatch(packet)
 
     async def _ping_loop(self) -> None:
         while True:
@@ -515,118 +516,14 @@ class MQTTProtocol:
                 msg = f"Unexpected packet from broker: {packet!r}"
                 raise MQTTProtocolError(msg)
 
-    def _select_subscription(self, publish: Publish) -> SubscriptionSelection:
-        identifier = publish.properties.subscription_identifier if publish.properties else None
-        if identifier is None:
-            return self._state.subscriptions.select(topic=publish.topic)
-        return self._state.subscriptions.select_by_identifier(
-            topic=publish.topic,
-            identifier=identifier,
-        )
-
     def _select_recipient(self, publish: Publish) -> InboundRecipient:
-        message = self._make_message(publish)
-        if self._request_router is not None:
-            request = self._request_router.claim(message)
-            if request is not None:
-                return InboundRecipient(
-                    message=message,
-                    request=request,
-                )
-
-        selection = self._select_subscription(publish)
-        if selection.identifier_missing:
-            identifier = publish.properties.subscription_identifier if publish.properties else None
-            log.warning(
-                "No subscription with identifier %r for topic %r, falling back to filter matching",
-                identifier,
-                publish.topic,
-            )
-        if selection.tied_filters:
-            log.warning(
-                "Multiple equally-specific subscribers for %r: %s, delivering to first",
-                publish.topic,
-                list(selection.tied_filters),
-            )
-        if selection.recipient is None:
-            log.warning("No subscriber for topic %r", publish.topic)
-        return InboundRecipient(
-            message=message,
-            subscription=selection.recipient,
-        )
+        return self.inbound.select_recipient(publish)
 
     async def _handle_publish(self, packet: Publish) -> None:
-        if packet.qos is QoS.AT_MOST_ONCE:
-            return await self._deliver(self._select_recipient(packet), ack_callback=None)
-        if packet.qos is QoS.AT_LEAST_ONCE:
-            return await self._handle_qos1_publish(packet)
-        if packet.qos is QoS.EXACTLY_ONCE:
-            return await self._handle_qos2_publish(packet)
-        return None
-
-    async def _handle_qos1_publish(self, packet: Publish) -> None:
-        if packet.packet_id is None:
-            msg = "Cannot publish without packet id"
-            raise ValueError(msg)
-        recipient = self._select_recipient(packet)
-        if recipient.auto_ack:
-            await self._send(self._encode(PubAck(packet_id=packet.packet_id)))
-            await self._deliver(recipient, ack_callback=None)
-        else:
-            acked = False
-
-            async def _puback() -> None:
-                nonlocal acked
-                if acked:
-                    return
-                acked = True
-                await self._send(self._encode(PubAck(packet_id=cast("int", packet.packet_id))))
-
-            await self._deliver(recipient, ack_callback=_puback)
-
-    async def _handle_qos2_publish(self, packet: Publish) -> None:
-        if packet.packet_id is None:
-            msg = "Cannot publish without packet id"
-            raise ValueError(msg)
-        if packet.packet_id in self._state.inflight_qos2_in:
-            # PUBREC already sent — resend it (duplicate PUBLISH after PUBREC)
-            await self._send(self._encode(PubRec(packet_id=packet.packet_id)))
-            return
-        if packet.packet_id in self._state.pending_ack_qos2_in:
-            # Duplicate PUBLISH while app hasn't called msg.ack() yet — ignore
-            return
-        recipient = self._select_recipient(packet)
-        if recipient.auto_ack:
-            self._state.inflight_qos2_in[packet.packet_id] = InboundQoS2Flight(
-                packet_id=packet.packet_id,
-                recipient=recipient,
-                state=InboundQoS2State.PENDING_PUBREL,
-            )
-            await self._send(self._encode(PubRec(packet_id=packet.packet_id)))
-        else:
-            self._state.pending_ack_qos2_in.add(packet.packet_id)
-            pid = packet.packet_id
-
-            async def _pubrec() -> None:
-                self._state.pending_ack_qos2_in.discard(pid)
-                self._state.inflight_qos2_in[pid] = InboundQoS2Flight(
-                    packet_id=pid,
-                    recipient=recipient,
-                    state=InboundQoS2State.PENDING_PUBREL,
-                    delivered=True,
-                )
-                await self._send(self._encode(PubRec(packet_id=pid)))
-
-            await self._deliver(recipient, ack_callback=_pubrec)
+        await self.inbound.handle_publish(packet)
 
     async def _handle_pubrel(self, packet: PubRel) -> None:
-        flight = self._state.inflight_qos2_in.pop(packet.packet_id, None)
-        if flight is None:
-            msg = f"PUBREL for unknown packet_id {packet.packet_id}"
-            raise MQTTProtocolError(msg)
-        await self._send(self._encode(PubComp(packet_id=packet.packet_id)))
-        if not flight.delivered:
-            await self._deliver(flight.recipient, ack_callback=None)
+        await self.inbound.handle_pubrel(packet)
 
     async def _handle_puback(self, packet: PubAck) -> None:
         flight = self._state.inflight_qos1.pop(packet.packet_id, None)
@@ -635,7 +532,7 @@ class MQTTProtocol:
             raise MQTTProtocolError(msg)
         self._state.packet_ids.release(packet.packet_id)
         flight.future.set_result(packet)
-        log.debug("QoS 1 ack received", extra={"packet_id": packet.packet_id})
+        log.debug("QoS 1 ack received for packet_id=%d", packet.packet_id)
 
     async def _handle_pubrec(self, packet: PubRec) -> None:
         flight = self._state.inflight_qos2_out.get(packet.packet_id)
@@ -649,10 +546,7 @@ class MQTTProtocol:
             )
         flight.state = OutboundQoS2State.PENDING_PUBCOMP
         await self._send(self._encode(PubRel(packet_id=packet.packet_id)))
-        log.debug(
-            "QoS 2 PUBREC received, sent PUBREL",
-            extra={"packet_id": packet.packet_id},
-        )
+        log.debug("QoS 2 PUBREC received, sent PUBREL for packet_id=%d", packet.packet_id)
 
     async def _handle_pubcomp(self, packet: PubComp) -> None:
         flight = self._state.inflight_qos2_out.pop(packet.packet_id, None)
@@ -661,7 +555,7 @@ class MQTTProtocol:
             raise MQTTProtocolError(msg)
         self._state.packet_ids.release(packet.packet_id)
         flight.future.set_result(packet)
-        log.debug("QoS 2 complete", extra={"packet_id": packet.packet_id})
+        log.debug("QoS 2 complete for packet_id=%d", packet.packet_id)
 
     async def _handle_suback(self, packet: SubAck) -> None:
         future = self._state.pending_subs.get(packet.packet_id)
@@ -689,38 +583,14 @@ class MQTTProtocol:
     def _encode(self, packet: AnyPacket) -> bytes:
         return encode(packet, version=self._version)
 
+    async def send_packet(self, packet: AnyPacket) -> None:
+        """Send an encoded packet on behalf of an internal protocol flow."""
+        await self._send(self._encode(packet))
+
+    async def abort(self) -> None:
+        """Close the transport after a terminal inbound-flow failure."""
+        await self._transport.close()
+
     async def _send(self, data: bytes) -> None:
         log.debug("Sending %d bytes", len(data))
         await self._transport.write(data)
-
-    async def _deliver(
-        self,
-        recipient: InboundRecipient,
-        ack_callback: Callable[[], Awaitable[None]] | None,
-    ) -> None:
-        if recipient.request is not None:
-            recipient.request.deliver()
-            return
-
-        subscription = recipient.subscription
-        if subscription is None:
-            return
-
-        filter_, entry = subscription
-        message = recipient.message
-        if not entry.auto_ack and ack_callback is not None:
-            message._ack_callback = ack_callback
-        await entry.queue.put(message)
-        log.debug(
-            "Delivered message",
-            extra={"topic": message.topic, "filter": filter_},
-        )
-
-    def _make_message(self, publish: Publish) -> Message:
-        return Message(
-            topic=publish.topic,
-            payload=publish.payload,
-            qos=publish.qos,
-            retain=publish.retain,
-            properties=publish.properties,
-        )

--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -185,7 +185,6 @@ class Subscription:
         self._qos = qos
         self._auto_ack = auto_ack
         self._queue: asyncio.Queue[Message] = asyncio.Queue(receive_buffer_size)
-        self._relay_tasks: list[asyncio.Task[None]] = []
         self._no_local = no_local
         self._retain_as_published = retain_as_published
         self._retain_handling = retain_handling
@@ -208,7 +207,6 @@ class Subscription:
     async def __aexit__(self, *exc: object) -> None:
         """Unsubscribe from all filters and stop message delivery."""
         self._client._subscriptions.remove(self)
-        await self._cancel_relays()
         being_cancelled = isinstance(exc[1], asyncio.CancelledError)
         if not being_cancelled and self._registered_filters and self._client._protocol is not None:
             with contextlib.suppress(Exception):
@@ -228,29 +226,14 @@ class Subscription:
         _, queues = await protocol.subscribe(
             reqs,
             auto_ack=self._auto_ack,
-            queue_maxsize=self._queue.maxsize,
+            queue=self._queue,
             subscription_identifier=self._subscription_identifier,
         )
         self._registered_filters = list(queues.keys())
-        for q in queues.values():
-            task: asyncio.Task[None] = asyncio.create_task(self._relay_loop(q))
-            self._relay_tasks.append(task)
-
-    async def _cancel_relays(self) -> None:
-        for t in self._relay_tasks:
-            t.cancel()
-        await asyncio.gather(*self._relay_tasks, return_exceptions=True)
-        self._relay_tasks.clear()
 
     async def _reconnect(self, protocol: MQTTProtocol) -> None:
         """Re-subscribe on a fresh protocol after reconnection."""
-        await self._cancel_relays()
         await self._do_subscribe(protocol)
-
-    async def _relay_loop(self, source: asyncio.Queue[Message]) -> None:
-        while True:
-            msg = await source.get()
-            await self._queue.put(msg)
 
     async def start(self) -> None:
         """Register the subscription filters with the broker.
@@ -274,9 +257,8 @@ class Subscription:
         """Unsubscribe from all filters and stop message delivery.
 
         Equivalent to exiting the async context manager. Sends UNSUBSCRIBE to
-        the broker and cancels internal relay tasks. Safe to call even if the
-        connection has already been lost — the UNSUBSCRIBE is silently skipped
-        in that case.
+        the broker. Safe to call even if the connection has already been lost —
+        the UNSUBSCRIBE is silently skipped in that case.
 
         Example::
 
@@ -292,7 +274,9 @@ class Subscription:
         """
         failure_signal = self._client._subscription_failure
         if failure_signal is None:
-            return await self._queue.get()
+            message = await self._queue.get()
+            await self._notify_capacity_available()
+            return message
         if failure_signal.done():
             raise failure_signal.result()
 
@@ -304,11 +288,18 @@ class Subscription:
             )
             if failure_signal in done:
                 raise failure_signal.result()
-            return message_task.result()
+            message = message_task.result()
+            await self._notify_capacity_available()
+            return message
         finally:
             if not message_task.done():
                 message_task.cancel()
             await asyncio.gather(message_task, return_exceptions=True)
+
+    async def _notify_capacity_available(self) -> None:
+        protocol = self._client._protocol
+        if protocol is not None:
+            await protocol.inbound.drain()
 
     def __aiter__(self) -> AsyncIterator[Message]:
         """Return self as the async iterator."""
@@ -346,6 +337,8 @@ class MQTTClient:
         session_expiry_interval: int = 0,
         stripped_prefixes: tuple[str, ...] = _DEFAULT_STRIPPED_PREFIXES,
         max_pending_requests: int = 1000,
+        session_replay_buffer_size: int = 1000,
+        session_replay_timeout: float = 30.0,
     ) -> None:
         """Create an MQTT client.
 
@@ -394,9 +387,21 @@ class MQTTClient:
                 delivers on unchanged (e.g. ``$SYS``) must not be listed.
             max_pending_requests: Maximum concurrent MQTT 5.0 ``request()`` calls.
                 Additional calls wait until capacity is available.
+            session_replay_buffer_size: Maximum unmatched messages held while a
+                resumed persistent session waits for local subscriptions. ``0``
+                makes the buffer unbounded. Defaults to ``1000``.
+            session_replay_timeout: Seconds a persistent-session message may
+                remain in the replay buffer. Remaining messages are dropped
+                without acknowledgement after the timeout. Defaults to ``30.0``.
         """
         if not mqtt_connect_timeout > 0:
             msg = "mqtt_connect_timeout must be positive"
+            raise ValueError(msg)
+        if session_replay_buffer_size < 0:
+            msg = "session_replay_buffer_size must be non-negative"
+            raise ValueError(msg)
+        if not session_replay_timeout > 0:
+            msg = "session_replay_timeout must be positive"
             raise ValueError(msg)
         if will is not None and will.properties is not None and version != "5.0":
             msg = "will properties require MQTT 5.0"
@@ -418,6 +423,8 @@ class MQTTClient:
         self._session_expiry_interval = session_expiry_interval
         self._stripped_prefixes = stripped_prefixes
         self._request_dispatcher = _RequestDispatcher(max_pending_requests)
+        self._session_replay_buffer_size = session_replay_buffer_size
+        self._session_replay_timeout = session_replay_timeout
         self._protocol: MQTTProtocol | None = None
         self._subscriptions: list[Subscription] = []
         self._run_task: asyncio.Task[None] | None = None
@@ -729,6 +736,8 @@ class MQTTClient:
             version=self._version,
             stripped_prefixes=self._stripped_prefixes,
             request_router=self._request_dispatcher,
+            session_replay_buffer_size=self._session_replay_buffer_size,
+            session_replay_timeout=self._session_replay_timeout,
         )
         connect_props = None
         if self._version == "5.0":
@@ -838,6 +847,8 @@ def create_client(
     transport_factory: TransportFactory | None = ...,
     session_expiry_interval: int = ...,
     max_pending_requests: int = ...,
+    session_replay_buffer_size: int = ...,
+    session_replay_timeout: float = ...,
 ) -> MQTTClientV311: ...
 
 
@@ -859,6 +870,8 @@ def create_client(
     transport_factory: TransportFactory | None = ...,
     session_expiry_interval: int = ...,
     max_pending_requests: int = ...,
+    session_replay_buffer_size: int = ...,
+    session_replay_timeout: float = ...,
     version: Literal["3.1.1"],
 ) -> MQTTClientV311: ...
 
@@ -881,6 +894,8 @@ def create_client(
     transport_factory: TransportFactory | None = ...,
     session_expiry_interval: int = ...,
     max_pending_requests: int = ...,
+    session_replay_buffer_size: int = ...,
+    session_replay_timeout: float = ...,
     version: Literal["5.0"],
 ) -> MQTTClientV5: ...
 
@@ -902,6 +917,8 @@ def create_client(
     transport_factory: TransportFactory | None = None,
     session_expiry_interval: int = 0,
     max_pending_requests: int = 1000,
+    session_replay_buffer_size: int = 1000,
+    session_replay_timeout: float = 30.0,
     version: Literal["3.1.1", "5.0"] = "3.1.1",
 ) -> MQTTClientV311 | MQTTClientV5:
     """Create a version-typed MQTT client.
@@ -926,4 +943,6 @@ def create_client(
         version=version,
         session_expiry_interval=session_expiry_interval,
         max_pending_requests=max_pending_requests,
+        session_replay_buffer_size=session_replay_buffer_size,
+        session_replay_timeout=session_replay_timeout,
     )

--- a/tests/test_brokers/_base.py
+++ b/tests/test_brokers/_base.py
@@ -32,6 +32,7 @@ class BrokerTestBase(abc.ABC):
     host: ClassVar[str] = "127.0.0.1"
     port: ClassVar[int] = 1883
     version: ClassVar[Literal["3.1.1", "5.0"]] = "3.1.1"
+    supports_persistent_sessions: ClassVar[bool] = True
 
     @abc.abstractmethod
     async def handle_sub_duplicates(
@@ -74,6 +75,23 @@ class BrokerTestBase(abc.ABC):
         protocol = client._protocol
         assert protocol is not None
         await protocol._transport.close()
+
+    def persistent_client(
+        self,
+        *,
+        client_id: str,
+        session_replay_timeout: float = 30.0,
+    ) -> MQTTClient:
+        return MQTTClient(
+            self.host,
+            self.port,
+            client_id=client_id,
+            clean_session=False,
+            reconnect=ReconnectConfig(enabled=False),
+            version=self.version,
+            session_expiry_interval=60 if self.version == "5.0" else 0,
+            session_replay_timeout=session_replay_timeout,
+        )
 
     async def test_ping(self, mqtt_client: MQTTClient) -> None:
         await mqtt_client.ping()
@@ -359,6 +377,144 @@ class BrokerTestBase(abc.ABC):
             message = await message_task
 
         assert message.payload == b"after-single-reconnect"
+
+    @pytest.mark.parametrize("qos", [QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
+    async def test_persistent_session_replay_waits_for_subscription(
+        self,
+        topic: str,
+        qos: QoS,
+    ) -> None:
+        if not self.supports_persistent_sessions:
+            pytest.skip("Broker test configuration does not retain persistent sessions")
+        client_id = f"zmqtt-session-replay-{uuid.uuid4().hex[:8]}"
+        original = self.persistent_client(client_id=client_id)
+        await original.connect()
+        original_subscription = original.subscribe(topic, qos=qos)
+        await original_subscription.start()
+        await original.disconnect()
+
+        async with MQTTClient(self.host, self.port, version=self.version) as publisher:
+            await publisher.publish(topic, b"while-offline", qos=qos)
+
+        resumed = self.persistent_client(client_id=client_id)
+        await resumed.connect()
+        await asyncio.sleep(0.2)
+        replay_subscription = resumed.subscribe(topic, qos=qos)
+        await replay_subscription.start()
+        message = await asyncio.wait_for(replay_subscription.get_message(), timeout=5.0)
+        assert message.payload == b"while-offline"
+        assert message.qos is qos
+        await replay_subscription.stop()
+        await resumed.disconnect()
+
+    async def test_persistent_session_replay_preserves_manual_ack(
+        self,
+        topic: str,
+    ) -> None:
+        if not self.supports_persistent_sessions:
+            pytest.skip("Broker test configuration does not retain persistent sessions")
+        client_id = f"zmqtt-session-manual-ack-{uuid.uuid4().hex[:8]}"
+        original = self.persistent_client(client_id=client_id)
+        await original.connect()
+        original_subscription = original.subscribe(topic, qos=QoS.AT_LEAST_ONCE)
+        await original_subscription.start()
+        await original.disconnect()
+
+        async with MQTTClient(self.host, self.port, version=self.version) as publisher:
+            await publisher.publish(topic, b"ack-after-replay", qos=QoS.AT_LEAST_ONCE)
+
+        resumed = self.persistent_client(client_id=client_id)
+        await resumed.connect()
+        await asyncio.sleep(0.2)
+        manual_subscription = resumed.subscribe(
+            topic,
+            qos=QoS.AT_LEAST_ONCE,
+            auto_ack=False,
+        )
+        await manual_subscription.start()
+        first_delivery = await asyncio.wait_for(manual_subscription.get_message(), timeout=5.0)
+        await resumed.disconnect()
+
+        replayed_again = self.persistent_client(client_id=client_id)
+        await replayed_again.connect()
+        await asyncio.sleep(0.2)
+        final_subscription = replayed_again.subscribe(topic, qos=QoS.AT_LEAST_ONCE)
+        await final_subscription.start()
+        second_delivery = await asyncio.wait_for(final_subscription.get_message(), timeout=5.0)
+        assert first_delivery.payload == b"ack-after-replay"
+        assert second_delivery.payload == first_delivery.payload
+        await final_subscription.stop()
+        await replayed_again.disconnect()
+
+    async def test_persistent_session_replay_respects_subscription_buffer(
+        self,
+        topic: str,
+    ) -> None:
+        if not self.supports_persistent_sessions:
+            pytest.skip("Broker test configuration does not retain persistent sessions")
+        client_id = f"zmqtt-session-backpressure-{uuid.uuid4().hex[:8]}"
+        original = self.persistent_client(client_id=client_id)
+        await original.connect()
+        original_subscription = original.subscribe(topic, qos=QoS.AT_LEAST_ONCE)
+        await original_subscription.start()
+        await original.disconnect()
+
+        async with MQTTClient(self.host, self.port, version=self.version) as publisher:
+            await publisher.publish(topic, b"first", qos=QoS.AT_LEAST_ONCE)
+            await publisher.publish(topic, b"second", qos=QoS.AT_LEAST_ONCE)
+
+        resumed = self.persistent_client(client_id=client_id)
+        await resumed.connect()
+        await asyncio.sleep(0.2)
+        replay_subscription = resumed.subscribe(
+            topic,
+            qos=QoS.AT_LEAST_ONCE,
+            receive_buffer_size=1,
+        )
+        await replay_subscription.start()
+        first = await asyncio.wait_for(replay_subscription.get_message(), timeout=5.0)
+        second = await asyncio.wait_for(replay_subscription.get_message(), timeout=5.0)
+        assert [first.payload, second.payload] == [b"first", b"second"]
+        await replay_subscription.stop()
+        await resumed.disconnect()
+
+    @pytest.mark.parametrize("qos", [QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
+    async def test_persistent_session_replay_drops_without_ack_after_timeout(
+        self,
+        topic: str,
+        qos: QoS,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        if not self.supports_persistent_sessions:
+            pytest.skip("Broker test configuration does not retain persistent sessions")
+        client_id = f"zmqtt-session-timeout-{uuid.uuid4().hex[:8]}"
+        original = self.persistent_client(client_id=client_id)
+        await original.connect()
+        original_subscription = original.subscribe(topic, qos=qos)
+        await original_subscription.start()
+        await original.disconnect()
+
+        async with MQTTClient(self.host, self.port, version=self.version) as publisher:
+            await publisher.publish(topic, b"expired", qos=qos)
+
+        resumed = self.persistent_client(
+            client_id=client_id,
+            session_replay_timeout=0.1,
+        )
+        await resumed.connect()
+        await asyncio.sleep(0.5)
+        await resumed.disconnect()
+
+        replayed_again = self.persistent_client(client_id=client_id)
+        await replayed_again.connect()
+        await asyncio.sleep(0.2)
+        replay_subscription = replayed_again.subscribe(topic, qos=qos)
+        await replay_subscription.start()
+        message = await asyncio.wait_for(replay_subscription.get_message(), timeout=5.0)
+        assert message.payload == b"expired"
+        assert any("Dropped 1 persistent-session replay messages" in message for message in caplog.messages)
+        await replay_subscription.stop()
+        await replayed_again.disconnect()
 
     async def test_tcp_disconnect_wakes_subscription_when_reconnect_disabled(self, topic: str) -> None:
         client = MQTTClient(

--- a/tests/test_brokers/test_nanomq.py
+++ b/tests/test_brokers/test_nanomq.py
@@ -7,6 +7,8 @@ from zmqtt import Subscription
 
 
 class BaseTestNanoMQ(BrokerTestBase):
+    supports_persistent_sessions = False
+
     async def handle_sub_duplicates(
         self,
         *,

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -245,7 +245,7 @@ async def test_configured_prefix_reaches_subscribe() -> None:
     async def subscribe() -> None:
         await protocol.subscribe(
             [SubscriptionRequest(topic_filter="$q/sensors/+/state", qos=QoS.AT_MOST_ONCE)],
-            queue_maxsize=4,
+            queue=asyncio.Queue(),
         )
 
     task = asyncio.create_task(subscribe())
@@ -258,7 +258,6 @@ async def test_configured_prefix_reaches_subscribe() -> None:
     entry = protocol._state.subscriptions.get("$q/sensors/+/state")
     assert entry is not None
     assert entry.actual_filter == "sensors/+/state"
-    assert entry.queue.maxsize == 4
 
 
 async def test_subscription_identifier_routes_delivery() -> None:
@@ -435,7 +434,7 @@ async def test_subscribe_sends_identifier_in_properties() -> None:
     async def subscribe() -> None:
         await protocol.subscribe(
             [SubscriptionRequest(topic_filter="a/b", qos=QoS.AT_LEAST_ONCE)],
-            queue_maxsize=3,
+            queue=asyncio.Queue(),
             subscription_identifier=7,
         )
 
@@ -454,7 +453,6 @@ async def test_subscribe_sends_identifier_in_properties() -> None:
     assert packet.properties.subscription_identifier == 7
     entry = protocol._state.subscriptions.get("a/b")
     assert entry is not None
-    assert entry.queue.maxsize == 3
     assert entry.subscription_identifier == 7
     assert protocol._state.subscriptions.by_identifier(7) == [("a/b", entry)]
 
@@ -490,6 +488,7 @@ async def test_dead_protocol_refuses_new_operations() -> None:
     with pytest.raises(MQTTDisconnectedError):
         await protocol.subscribe(
             [SubscriptionRequest(topic_filter="a/b", qos=QoS.AT_MOST_ONCE)],
+            queue=asyncio.Queue(),
         )
 
 
@@ -520,6 +519,7 @@ async def test_suback_failure_rolls_back_subscription_index() -> None:
     task = asyncio.create_task(
         protocol.subscribe(
             [SubscriptionRequest(topic_filter="denied/topic", qos=QoS.AT_LEAST_ONCE)],
+            queue=asyncio.Queue(),
             subscription_identifier=7,
         ),
     )


### PR DESCRIPTION
## Summary

Described in docs. Fixes #59

## Validation

<!-- Which checks did you run? -->

- [ ] Tests were added or updated when behavior changed
- [ ] Documentation was updated when the public API changed
- [ ] The PR title follows Conventional Commits, for example `feat(client): add reconnect timeout`
