### PR TITLE
fix(publish): Raise MQTTPublishError on negative PUBACK/PUBREC reason codes.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -65,21 +65,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup mosquitto config
-        run: |
-          mkdir -p docker
-          cat > docker/mosquitto.conf <<EOF
-          listener 1883
-          allow_anonymous true
-          EOF
-
       - name: Copy mosquitto config
         env:
           MOSQUITTO_ID: ${{ job.services.mosquitto.id }}
         run: |
           echo "Mosquitto container: $MOSQUITTO_ID"
           docker cp docker/mosquitto.conf "$MOSQUITTO_ID:/mosquitto/config/mosquitto.conf"
-          docker exec "$MOSQUITTO_ID" chmod 644 /mosquitto/config/mosquitto.conf
+          docker cp docker/mosquitto.acl "$MOSQUITTO_ID:/mosquitto/config/mosquitto.acl"
+          docker exec "$MOSQUITTO_ID" chmod 644 \
+            /mosquitto/config/mosquitto.conf \
+            /mosquitto/config/mosquitto.acl
+          # SIGHUP reloads the config and the ACL file without dropping the
+          # listener, so the service container keeps its published port.
+          docker kill -s HUP "$MOSQUITTO_ID"
 
       - name: Wait for brokers
         run: |
@@ -125,7 +123,8 @@ jobs:
       - name: Install and start mosquitto
         run: |
           brew install mosquitto
-          printf 'listener 1884\nallow_anonymous true\n' > /tmp/mosquitto.conf
+          printf 'listener 1884\nallow_anonymous true\nacl_file %s\n' \
+            "$GITHUB_WORKSPACE/docker/mosquitto.acl" > /tmp/mosquitto.conf
           $(brew --prefix)/sbin/mosquitto -c /tmp/mosquitto.conf -d
           sleep 2
 
@@ -152,7 +151,8 @@ jobs:
         shell: pwsh
         run: |
           winget install -e --id EclipseFoundation.Mosquitto --accept-source-agreements --accept-package-agreements --silent
-          Set-Content -Path "$env:TEMP\mosquitto.conf" -Value "listener 1884`r`nallow_anonymous true"
+          $acl = "$env:GITHUB_WORKSPACE\docker\mosquitto.acl"
+          Set-Content -Path "$env:TEMP\mosquitto.conf" -Value "listener 1884`r`nallow_anonymous true`r`nacl_file $acl"
           Start-Process -FilePath "C:\Program Files\mosquitto\mosquitto.exe" -ArgumentList "-c $env:TEMP\mosquitto.conf" -WindowStyle Hidden
           Start-Sleep -Seconds 3
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ site
 
 .coverage
 htmlcov
+.vscode

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,7 @@ services:
     image: eclipse-mosquitto:2
     volumes:
       - ./docker/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+      - ./docker/mosquitto.acl:/mosquitto/config/mosquitto.acl:ro
     ports:
       - "1884:1883"
     security_opt:

--- a/docker/mosquitto.acl
+++ b/docker/mosquitto.acl
@@ -1,0 +1,6 @@
+# ACL for the test broker. Setting acl_file in mosquitto.conf switches mosquitto to
+# deny-by-default, so the file allows every topic and then denies only the one topic
+# the publish-rejection test needs.
+topic readwrite #
+topic readwrite $SYS/#
+topic deny zmqtt/e2e/denied

--- a/docker/mosquitto.conf
+++ b/docker/mosquitto.conf
@@ -1,2 +1,3 @@
 listener 1883
 allow_anonymous true
+acl_file /mosquitto/config/mosquitto.acl

--- a/docs/advanced/mqtt5.md
+++ b/docs/advanced/mqtt5.md
@@ -149,6 +149,33 @@ Common failed-CONNACK reason codes are:
 
 See the [MQTT 5.0 spec](https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html) for the full list.
 
+## PUBACK and PUBREC reason codes
+
+PUBACK (QoS 1) and PUBREC (QoS 2) also carry a reason code in MQTT 5.0. A code
+below `0x80` — including `0x00` (Success) and `0x10` (No matching
+subscribers) — completes `publish()` normally. A code of `0x80` or greater
+raises [`MQTTPublishError`](../error-handling.md#mqttpublisherror):
+
+```python
+from zmqtt import MQTTPublishError, QoS
+
+try:
+    await client.publish("private/topic", b"payload", qos=QoS.AT_LEAST_ONCE)
+except MQTTPublishError as e:
+    print(f"Publish rejected: 0x{e.reason_code:02X} ({e.reason_name})")
+```
+
+`reason_name` is the spec's name for the code. The broker's optional Reason
+String property is exposed separately as `reason_string`, and is `None` when
+the broker omits it.
+
+This check does not apply to `version="3.1.1"` connections, where PUBACK and
+PUBREC carry no reason code.
+
+See the MQTT 5.0 spec for the permitted reason codes:
+[PUBACK](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901124)
+and [PUBREC](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901134).
+
 ---
 
 **See also:** [Connecting — Version selection](../connecting.md#version-selection) · [Publishing](../publishing.md) · [Subscribing](../subscribing.md) · [Error Handling](../error-handling.md)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -115,6 +115,10 @@
     options:
       show_source: false
 
+::: zmqtt.MQTTPublishError
+    options:
+      show_source: false
+
 ::: zmqtt.MQTTInvalidTopicError
     options:
       show_source: false

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -9,6 +9,7 @@ MQTTError
   ├── MQTTDisconnectedError # connection lost unexpectedly
   ├── MQTTTimeoutError      # PINGRESP or CONNACK timed out
   ├── MQTTSubscribeError    # one or more filters rejected by the broker
+  ├── MQTTPublishError      # QoS 1/2 publish rejected by the broker
   └── MQTTInvalidTopicError # topic string failed MQTT validation
 ```
 
@@ -22,6 +23,7 @@ from zmqtt import (
     MQTTDisconnectedError,
     MQTTTimeoutError,
     MQTTSubscribeError,
+    MQTTPublishError,
     MQTTInvalidTopicError,
 )
 ```
@@ -68,6 +70,36 @@ except MQTTSubscribeError as e:
 ```
 
 The same exception is raised by `await sub.start()` when using the manual subscription lifecycle.
+
+### `MQTTPublishError`
+
+Raised on a `version="5.0"` connection when the broker rejects a QoS 1 or QoS 2
+`publish()` — a PUBACK or PUBREC reason code of `0x80` or greater. A common
+cause is an authorization denial. The `reason_code` attribute holds the numeric
+code, `reason_name` the spec's name for it (`None` for a code zmqtt doesn't
+recognize), and `reason_string` the broker's optional Reason String property:
+
+```python
+from zmqtt import MQTTPublishError, QoS
+
+try:
+    await client.publish("private/topic", b"payload", qos=QoS.AT_LEAST_ONCE)
+except MQTTPublishError as e:
+    print(f"Publish rejected: 0x{e.reason_code:02X} ({e.reason_name})")
+```
+
+For QoS 2, a rejected PUBREC ends the handshake immediately — no PUBREL is
+sent, since MQTT 5.0 only permits PUBREL after a PUBREC reason code below
+`0x80`. In both cases the packet identifier is released and the connection
+remains usable for further operations.
+
+Not raised for QoS 0, and not raised at all on `version="3.1.1"` connections —
+PUBACK and PUBREC carry no reason code in that protocol version, so a rejected
+publish there completes without error unless the broker instead closes the
+connection.
+
+See [PUBACK and PUBREC reason codes](advanced/mqtt5.md#puback-and-pubrec-reason-codes)
+for more detail.
 
 ### `MQTTProtocolError`
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -37,6 +37,11 @@ QoS 2 does not make arbitrary application side effects exactly once. A process
 can still fail between changing application state and completing the MQTT
 handshake, so handlers that write to external systems should remain idempotent.
 
+On a `version="5.0"` connection, a QoS 1 or QoS 2 `publish()` raises
+`MQTTPublishError` if the broker's PUBACK/PUBREC reports a reason code of
+`0x80` or greater (for example, an ACL denial) — see
+[`MQTTPublishError`](error-handling.md#mqttpublisherror).
+
 ## Retain flag
 
 A retained message is stored by the broker and delivered to any future subscriber immediately on subscribe:

--- a/src/zmqtt/__init__.py
+++ b/src/zmqtt/__init__.py
@@ -18,6 +18,7 @@ from zmqtt.errors import (
     MQTTError,
     MQTTInvalidTopicError,
     MQTTProtocolError,
+    MQTTPublishError,
     MQTTSubscribeError,
     MQTTTimeoutError,
 )
@@ -33,6 +34,7 @@ __all__ = (
     "MQTTError",
     "MQTTInvalidTopicError",
     "MQTTProtocolError",
+    "MQTTPublishError",
     "MQTTSubscribeError",
     "MQTTTimeoutError",
     "Message",

--- a/src/zmqtt/_internal/protocol.py
+++ b/src/zmqtt/_internal/protocol.py
@@ -39,11 +39,25 @@ from zmqtt.errors import (
     MQTTConnectError,
     MQTTDisconnectedError,
     MQTTProtocolError,
+    MQTTPublishError,
     MQTTSubscribeError,
     MQTTTimeoutError,
 )
 
 log = logging.getLogger("zmqtt.protocol")
+
+# see: https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901124
+_PUBLISH_REASON_NAMES: Final[dict[int, str]] = {
+    0x00: "Success",
+    0x10: "No matching subscribers",
+    0x80: "Unspecified error",
+    0x83: "Implementation specific error",
+    0x87: "Not authorized",
+    0x90: "Topic Name invalid",
+    0x91: "Packet Identifier in use",
+    0x97: "Quota exceeded",
+    0x99: "Payload format invalid",
+}
 
 
 class _SubscriptionGuard:
@@ -93,6 +107,25 @@ def _raise_on_rejected_filters(filters: list[SubscriptionRequest], suback: SubAc
     failures = {req.topic_filter: code for req, code in zip(filters, suback.return_codes, strict=False) if code >= 0x80}
     if failures:
         raise MQTTSubscribeError(failures)
+
+
+def _publish_error(packet: PubAck | PubRec) -> MQTTPublishError:
+    return MQTTPublishError(
+        packet.reason_code,
+        _PUBLISH_REASON_NAMES.get(packet.reason_code),
+        packet.properties.reason_string if packet.properties is not None else None,
+    )
+
+
+def _raise_on_rejected_puback(puback: PubAck) -> None:
+    """Surface PUBACK failure codes (>= 0x80) instead of ignoring them.
+
+    A rejected publish otherwise looks exactly like a successful publish.
+    """
+    if puback.reason_code >= 0x80:
+        err = _publish_error(puback)
+        log.debug("QoS 1 ack received with error for packet_id=%d: %s", puback.packet_id, err)
+        raise err
 
 
 class MQTTProtocol:
@@ -252,7 +285,9 @@ class MQTTProtocol:
                 )
                 await self._send(self._encode(packet))
                 log.debug("Published QoS 1 to topic %r with packet_id=%d", packet.topic, pid)
-                return await future
+                ack = await future
+                _raise_on_rejected_puback(ack)
+                return ack
 
             case QoS.EXACTLY_ONCE:
                 loop = asyncio.get_running_loop()
@@ -531,7 +566,8 @@ class MQTTProtocol:
             msg = f"PUBACK for unknown packet_id {packet.packet_id}"
             raise MQTTProtocolError(msg)
         self._state.packet_ids.release(packet.packet_id)
-        flight.future.set_result(packet)
+        if not flight.future.done():
+            flight.future.set_result(packet)
         log.debug("QoS 1 ack received for packet_id=%d", packet.packet_id)
 
     async def _handle_pubrec(self, packet: PubRec) -> None:
@@ -544,6 +580,18 @@ class MQTTProtocol:
             raise MQTTProtocolError(
                 msg,
             )
+        # Unlike PUBACK/SUBACK, a negative PUBREC has no follow-up packet — MQTT 5
+        # terminates the QoS 2 flow here instead of sending PUBCOMP. The error must
+        # be raised from the handler because it also decides not to send PUBREL below.
+        if packet.reason_code >= 0x80:
+            self._state.inflight_qos2_out.pop(packet.packet_id, None)
+            self._state.packet_ids.release(packet.packet_id)
+            err = _publish_error(packet)
+            if not flight.future.done():
+                flight.future.set_exception(err)
+            log.debug("QoS 2 ack received with error for packet_id=%d: %s", packet.packet_id, err)
+            return
+
         flight.state = OutboundQoS2State.PENDING_PUBCOMP
         await self._send(self._encode(PubRel(packet_id=packet.packet_id)))
         log.debug("QoS 2 PUBREC received, sent PUBREL for packet_id=%d", packet.packet_id)
@@ -554,7 +602,8 @@ class MQTTProtocol:
             msg = f"PUBCOMP for unknown packet_id {packet.packet_id}"
             raise MQTTProtocolError(msg)
         self._state.packet_ids.release(packet.packet_id)
-        flight.future.set_result(packet)
+        if not flight.future.done():
+            flight.future.set_result(packet)
         log.debug("QoS 2 complete for packet_id=%d", packet.packet_id)
 
     async def _handle_suback(self, packet: SubAck) -> None:

--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -510,6 +510,7 @@ class MQTTClient:
                 ``$`` in a non-leading position.
             MQTTDisconnectedError: If the client is not currently connected.
             RuntimeError: If *properties* is supplied on an MQTT 3.1.1 connection.
+            MQTTPublishError: If the broker rejects a QoS 1/2 publish. Not raised for QoS 0 or MQTT 3.1.1.
         """
         validate_publish(topic)
         if self._protocol is None:

--- a/src/zmqtt/errors.py
+++ b/src/zmqtt/errors.py
@@ -35,5 +35,27 @@ class MQTTSubscribeError(MQTTError):
         super().__init__(f"Broker rejected subscription: {rendered}")
 
 
+class MQTTPublishError(MQTTError):
+    """The broker rejected a QoS 1/2 publish.
+
+    *reason_name* is the spec's name for *reason_code* (``None`` for a code
+    zmqtt does not recognize). *reason_string* is the broker's optional Reason
+    String property.
+    """
+
+    def __init__(
+        self,
+        reason_code: int,
+        reason_name: str | None,
+        reason_string: str | None,
+    ) -> None:
+        self.reason_code = reason_code
+        self.reason_name = reason_name
+        self.reason_string = reason_string
+        named = f"0x{reason_code:02X} {reason_name}" if reason_name else f"0x{reason_code:02X}"
+        detail = f": {reason_string}" if reason_string else ""
+        super().__init__(f"Broker rejected publish ({named}){detail}")
+
+
 class MQTTInvalidTopicError(MQTTError):
     """Topic string or topic filter failed MQTT validation."""

--- a/tests/test_brokers/_base.py
+++ b/tests/test_brokers/_base.py
@@ -7,6 +7,7 @@ Run with:  pytest -m broker
 import abc
 import asyncio
 import contextlib
+import re
 import uuid
 from collections.abc import AsyncGenerator
 from typing import ClassVar, Literal
@@ -17,6 +18,7 @@ from zmqtt import (
     MQTTClient,
     MQTTDisconnectedError,
     MQTTProtocolError,
+    MQTTPublishError,
     PublishProperties,
     QoS,
     ReconnectConfig,
@@ -33,6 +35,8 @@ class BrokerTestBase(abc.ABC):
     port: ClassVar[int] = 1883
     version: ClassVar[Literal["3.1.1", "5.0"]] = "3.1.1"
     supports_persistent_sessions: ClassVar[bool] = True
+    has_publish_deny_acl: ClassVar[bool] = False
+    denied_topic: ClassVar[str] = "zmqtt/e2e/denied"
 
     @abc.abstractmethod
     async def handle_sub_duplicates(
@@ -93,6 +97,12 @@ class BrokerTestBase(abc.ABC):
             session_replay_timeout=session_replay_timeout,
         )
 
+    def _skip_unless_denied_topic(self, version: Literal["3.1.1", "5.0"]) -> None:
+        if not self.has_publish_deny_acl:
+            pytest.skip("Broker under test has no ACL denying publish to denied_topic")
+        if self.version != version:
+            pytest.skip(f"Test covers MQTT {version} behaviour only")
+
     async def test_ping(self, mqtt_client: MQTTClient) -> None:
         await mqtt_client.ping()
 
@@ -104,6 +114,57 @@ class BrokerTestBase(abc.ABC):
 
     async def test_publish_qos2(self, mqtt_client: MQTTClient, topic: str) -> None:
         await mqtt_client.publish(topic, b"hello", qos=QoS.EXACTLY_ONCE)
+
+    @pytest.mark.parametrize("qos", [QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
+    async def test_publish_in_denied_topic_raises_error(
+        self,
+        mqtt_client: MQTTClient,
+        qos: QoS,
+    ) -> None:
+        self._skip_unless_denied_topic("5.0")
+
+        with pytest.raises(
+            MQTTPublishError, match=re.escape("Broker rejected publish (0x87 Not authorized)")
+        ) as exc_info:
+            await mqtt_client.publish(self.denied_topic, b"denied", qos=qos)
+
+        assert exc_info.value.reason_code == 0x87
+        assert exc_info.value.reason_name == "Not authorized"
+
+    @pytest.mark.parametrize("qos", [QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
+    async def test_publish_in_denied_topic_remains_connection_usable(
+        self,
+        mqtt_client: MQTTClient,
+        qos: QoS,
+        topic: str,
+    ) -> None:
+        self._skip_unless_denied_topic("5.0")
+        with pytest.raises(MQTTPublishError, match=re.escape("Broker rejected publish (0x87 Not authorized)")):
+            await mqtt_client.publish(self.denied_topic, b"denied", qos=qos)
+
+        async with mqtt_client.subscribe(topic) as sub:
+            await mqtt_client.publish(topic, b"payload-qos0")
+            msg = await sub.get_message()
+
+        assert msg.topic == topic
+        assert msg.payload == b"payload-qos0"
+
+    @pytest.mark.parametrize("qos", [QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
+    async def test_publish_in_denied_topic_mqtt311_does_not_raise(
+        self,
+        mqtt_client: MQTTClient,
+        qos: QoS,
+        topic: str,
+    ) -> None:
+        self._skip_unless_denied_topic("3.1.1")
+        await mqtt_client.publish(self.denied_topic, b"denied", qos=qos)
+
+        async with mqtt_client.subscribe(topic) as sub:
+            await mqtt_client.publish(topic, b"payload-qos0")
+            msg = await sub.get_message()
+
+        assert msg.topic == topic
+        assert msg.payload == b"payload-qos0"
 
     async def test_subscribe_receive_qos0(
         self,

--- a/tests/test_brokers/_base.py
+++ b/tests/test_brokers/_base.py
@@ -7,7 +7,6 @@ Run with:  pytest -m broker
 import abc
 import asyncio
 import contextlib
-import re
 import uuid
 from collections.abc import AsyncGenerator
 from typing import ClassVar, Literal
@@ -18,7 +17,6 @@ from zmqtt import (
     MQTTClient,
     MQTTDisconnectedError,
     MQTTProtocolError,
-    MQTTPublishError,
     PublishProperties,
     QoS,
     ReconnectConfig,
@@ -35,8 +33,6 @@ class BrokerTestBase(abc.ABC):
     port: ClassVar[int] = 1883
     version: ClassVar[Literal["3.1.1", "5.0"]] = "3.1.1"
     supports_persistent_sessions: ClassVar[bool] = True
-    has_publish_deny_acl: ClassVar[bool] = False
-    denied_topic: ClassVar[str] = "zmqtt/e2e/denied"
 
     @abc.abstractmethod
     async def handle_sub_duplicates(
@@ -97,12 +93,6 @@ class BrokerTestBase(abc.ABC):
             session_replay_timeout=session_replay_timeout,
         )
 
-    def _skip_unless_denied_topic(self, version: Literal["3.1.1", "5.0"]) -> None:
-        if not self.has_publish_deny_acl:
-            pytest.skip("Broker under test has no ACL denying publish to denied_topic")
-        if self.version != version:
-            pytest.skip(f"Test covers MQTT {version} behaviour only")
-
     async def test_ping(self, mqtt_client: MQTTClient) -> None:
         await mqtt_client.ping()
 
@@ -114,57 +104,6 @@ class BrokerTestBase(abc.ABC):
 
     async def test_publish_qos2(self, mqtt_client: MQTTClient, topic: str) -> None:
         await mqtt_client.publish(topic, b"hello", qos=QoS.EXACTLY_ONCE)
-
-    @pytest.mark.parametrize("qos", [QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
-    async def test_publish_in_denied_topic_raises_error(
-        self,
-        mqtt_client: MQTTClient,
-        qos: QoS,
-    ) -> None:
-        self._skip_unless_denied_topic("5.0")
-
-        with pytest.raises(
-            MQTTPublishError, match=re.escape("Broker rejected publish (0x87 Not authorized)")
-        ) as exc_info:
-            await mqtt_client.publish(self.denied_topic, b"denied", qos=qos)
-
-        assert exc_info.value.reason_code == 0x87
-        assert exc_info.value.reason_name == "Not authorized"
-
-    @pytest.mark.parametrize("qos", [QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
-    async def test_publish_in_denied_topic_remains_connection_usable(
-        self,
-        mqtt_client: MQTTClient,
-        qos: QoS,
-        topic: str,
-    ) -> None:
-        self._skip_unless_denied_topic("5.0")
-        with pytest.raises(MQTTPublishError, match=re.escape("Broker rejected publish (0x87 Not authorized)")):
-            await mqtt_client.publish(self.denied_topic, b"denied", qos=qos)
-
-        async with mqtt_client.subscribe(topic) as sub:
-            await mqtt_client.publish(topic, b"payload-qos0")
-            msg = await sub.get_message()
-
-        assert msg.topic == topic
-        assert msg.payload == b"payload-qos0"
-
-    @pytest.mark.parametrize("qos", [QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
-    async def test_publish_in_denied_topic_mqtt311_does_not_raise(
-        self,
-        mqtt_client: MQTTClient,
-        qos: QoS,
-        topic: str,
-    ) -> None:
-        self._skip_unless_denied_topic("3.1.1")
-        await mqtt_client.publish(self.denied_topic, b"denied", qos=qos)
-
-        async with mqtt_client.subscribe(topic) as sub:
-            await mqtt_client.publish(topic, b"payload-qos0")
-            msg = await sub.get_message()
-
-        assert msg.topic == topic
-        assert msg.payload == b"payload-qos0"
 
     async def test_subscribe_receive_qos0(
         self,

--- a/tests/test_brokers/test_mosquitto.py
+++ b/tests/test_brokers/test_mosquitto.py
@@ -1,13 +1,17 @@
 import asyncio
+import re
 
 import pytest
 
 from tests.test_brokers._base import BrokerTestBase
 from zmqtt import Subscription
+from zmqtt._internal.types.qos import QoS
+from zmqtt.client import MQTTClient
+from zmqtt.errors import MQTTPublishError
 
 
 class BaseTestMosquitto(BrokerTestBase):
-    has_publish_deny_acl = True
+    denied_topic = "zmqtt/e2e/denied"
 
     async def handle_sub_duplicates(
         self,
@@ -26,8 +30,55 @@ class TestMosquittoV311(BaseTestMosquitto):
     port = 1884
     version = "3.1.1"
 
+    @pytest.mark.parametrize("qos", [QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
+    async def test_publish_in_denied_topic_mqtt311_does_not_raise(
+        self,
+        mqtt_client: MQTTClient,
+        qos: QoS,
+        topic: str,
+    ) -> None:
+        await mqtt_client.publish(self.denied_topic, b"denied", qos=qos)
+
+        async with mqtt_client.subscribe(topic) as sub:
+            await mqtt_client.publish(topic, b"payload-qos0")
+            msg = await sub.get_message()
+
+        assert msg.topic == topic
+        assert msg.payload == b"payload-qos0"
+
 
 class TestMosquittoV5(BaseTestMosquitto):
     host = "127.0.0.1"
     port = 1884
     version = "5.0"
+
+    @pytest.mark.parametrize("qos", [QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
+    async def test_publish_in_denied_topic_raises_error(
+        self,
+        mqtt_client: MQTTClient,
+        qos: QoS,
+    ) -> None:
+        with pytest.raises(
+            MQTTPublishError, match=re.escape("Broker rejected publish (0x87 Not authorized)")
+        ) as exc_info:
+            await mqtt_client.publish(self.denied_topic, b"denied", qos=qos)
+
+        assert exc_info.value.reason_code == 0x87
+        assert exc_info.value.reason_name == "Not authorized"
+
+    @pytest.mark.parametrize("qos", [QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
+    async def test_publish_in_denied_topic_remains_connection_usable(
+        self,
+        mqtt_client: MQTTClient,
+        qos: QoS,
+        topic: str,
+    ) -> None:
+        with pytest.raises(MQTTPublishError, match=re.escape("Broker rejected publish (0x87 Not authorized)")):
+            await mqtt_client.publish(self.denied_topic, b"denied", qos=qos)
+
+        async with mqtt_client.subscribe(topic) as sub:
+            await mqtt_client.publish(topic, b"payload-qos0")
+            msg = await sub.get_message()
+
+        assert msg.topic == topic
+        assert msg.payload == b"payload-qos0"

--- a/tests/test_brokers/test_mosquitto.py
+++ b/tests/test_brokers/test_mosquitto.py
@@ -7,6 +7,8 @@ from zmqtt import Subscription
 
 
 class BaseTestMosquitto(BrokerTestBase):
+    has_publish_deny_acl = True
+
     async def handle_sub_duplicates(
         self,
         *,

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -15,13 +15,15 @@ import pytest
 from zmqtt._internal.packets.codec import encode
 from zmqtt._internal.packets.connect import ConnAck, Connect
 from zmqtt._internal.packets.disconnect import Disconnect
-from zmqtt._internal.packets.properties import PublishProperties
-from zmqtt._internal.packets.publish import PubAck, Publish, PubRel
+from zmqtt._internal.packets.properties import PubAckProperties, PublishProperties
+from zmqtt._internal.packets.publish import PubAck, Publish, PubRec, PubRel
 from zmqtt._internal.packets.reader import PacketBuffer
 from zmqtt._internal.packets.subscribe import SubAck, Subscribe, SubscriptionRequest
 from zmqtt._internal.protocol import (
+    _PUBLISH_REASON_NAMES,
     MQTTProtocol,
     _raise_on_rejected_filters,
+    _raise_on_rejected_puback,
 )
 from zmqtt._internal.state import SessionState
 from zmqtt._internal.subscription_index import SubscriptionEntry
@@ -32,9 +34,12 @@ from zmqtt.errors import (
     MQTTConnectError,
     MQTTDisconnectedError,
     MQTTProtocolError,
+    MQTTPublishError,
     MQTTSubscribeError,
     MQTTTimeoutError,
 )
+
+PUBLISH_FAILURE_CODES = [code for code in _PUBLISH_REASON_NAMES if code >= 0x80]
 
 
 class FakeTransport:
@@ -591,3 +596,108 @@ async def test_inbound_qos2_manual_ack_duplicate_ignored() -> None:
     assert queue.empty()
 
     await _stop_task(read_task)
+
+
+@pytest.mark.parametrize("reason_code", [0x00, 0x10])
+async def test_publish_qos1_accepted_puback_returns_ack(reason_code: int) -> None:
+    """0x00 and 0x10 (No matching subscribers) are successes: publish() returns the PubAck."""
+    protocol, transport = make_protocol(version="5.0")
+    transport.feed(encode(ConnAck(session_present=False, return_code=0), version="5.0"))
+    await protocol.connect(Connect(client_id="c", clean_session=True, keepalive=60))
+    read_task = await _run_read_loop(protocol)
+    publish_task = asyncio.create_task(
+        protocol.publish(
+            Publish(topic="t/x", payload=b"payload", qos=QoS.AT_LEAST_ONCE, retain=False, dup=False, packet_id=0),
+        ),
+    )
+    await asyncio.sleep(0)
+    pid = next(iter(protocol._state.inflight_qos1))
+
+    transport.feed(encode(PubAck(packet_id=pid, reason_code=reason_code), version="5.0"))
+    ack = await publish_task
+
+    assert ack == PubAck(packet_id=pid, reason_code=reason_code)
+    assert pid not in protocol._state.inflight_qos1
+    await _stop_task(read_task)
+
+
+def test_puback_failure_with_unknown_error_code_sets_reason_name_none() -> None:
+    puback = PubAck(packet_id=1, reason_code=0xFF)
+
+    with pytest.raises(MQTTPublishError) as exc_info:
+        _raise_on_rejected_puback(puback)
+
+    assert exc_info.value.reason_code == 0xFF
+    assert exc_info.value.reason_name is None
+
+
+def test_puback_failure_preserves_broker_reason_string() -> None:
+    puback = PubAck(
+        packet_id=1,
+        reason_code=0x87,
+        properties=PubAckProperties(reason_string="acl denied"),
+    )
+
+    with pytest.raises(MQTTPublishError) as exc_info:
+        _raise_on_rejected_puback(puback)
+
+    assert exc_info.value.reason_name == "Not authorized"
+    assert exc_info.value.reason_string == "acl denied"
+    assert str(exc_info.value) == "Broker rejected publish (0x87 Not authorized): acl denied"
+
+
+@pytest.mark.parametrize("reason_code", PUBLISH_FAILURE_CODES)
+async def test_publish_qos1_rejected_puback_raises_and_releases_packet_id(reason_code: int) -> None:
+    """publish() raises MQTTPublishError on a rejected PUBACK and frees the packet_id."""
+    protocol, transport = make_protocol(version="5.0")
+    transport.feed(encode(ConnAck(session_present=False, return_code=0), version="5.0"))
+    await protocol.connect(Connect(client_id="c", clean_session=True, keepalive=60))
+    transport.sent.clear()
+    read_task = await _run_read_loop(protocol)
+    publish_task = asyncio.create_task(
+        protocol.publish(
+            Publish(topic="t/x", payload=b"payload", qos=QoS.AT_LEAST_ONCE, retain=False, dup=False, packet_id=0),
+        ),
+    )
+    await asyncio.sleep(0)
+    pid = next(iter(protocol._state.inflight_qos1))
+
+    transport.feed(encode(PubAck(packet_id=pid, reason_code=reason_code), version="5.0"))
+    with pytest.raises(MQTTPublishError) as exc_info:
+        await publish_task
+
+    assert exc_info.value.reason_code == reason_code
+    assert exc_info.value.reason_name == _PUBLISH_REASON_NAMES[reason_code]
+    assert pid not in protocol._state.inflight_qos1
+    assert protocol._state.packet_ids.acquire() == pid  # proves release: id is reused
+    await _stop_task(read_task)
+
+
+@pytest.mark.parametrize("reason_code", PUBLISH_FAILURE_CODES)
+async def test_publish_qos2_rejected_pubrec_raises_no_pubrel_and_releases_packet_id(reason_code: int) -> None:
+    """publish() raises MQTTPublishError on a rejected PUBREC, sends no PUBREL, and frees the packet_id."""
+    protocol, transport = make_protocol(version="5.0")
+    transport.feed(encode(ConnAck(session_present=False, return_code=0), version="5.0"))
+    await protocol.connect(Connect(client_id="c", clean_session=True, keepalive=60))
+    transport.sent.clear()
+    read_task = await _run_read_loop(protocol)
+    publish_task = asyncio.create_task(
+        protocol.publish(
+            Publish(topic="t/x", payload=b"payload", qos=QoS.EXACTLY_ONCE, retain=False, dup=False, packet_id=0),
+        ),
+    )
+    await asyncio.sleep(0)
+    pid = next(iter(protocol._state.inflight_qos2_out))
+    sent_before_ack = len(transport.sent)
+
+    transport.feed(encode(PubRec(packet_id=pid, reason_code=reason_code), version="5.0"))
+    with pytest.raises(MQTTPublishError) as exc_info:
+        await publish_task
+
+    assert exc_info.value.reason_code == reason_code
+    assert exc_info.value.reason_name == _PUBLISH_REASON_NAMES[reason_code]
+    assert pid not in protocol._state.inflight_qos2_out
+    assert len(transport.sent) == sent_before_ack  # no PUBREL sent
+    assert protocol._state.packet_ids.acquire() == pid  # proves release: id is reused
+    await _stop_task(read_task)
+

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -700,4 +700,3 @@ async def test_publish_qos2_rejected_pubrec_raises_no_pubrel_and_releases_packet
     assert len(transport.sent) == sent_before_ack  # no PUBREL sent
     assert protocol._state.packet_ids.acquire() == pid  # proves release: id is reused
     await _stop_task(read_task)
-

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -15,7 +15,7 @@ import pytest
 from zmqtt._internal.packets.codec import encode
 from zmqtt._internal.packets.connect import ConnAck, Connect
 from zmqtt._internal.packets.disconnect import Disconnect
-from zmqtt._internal.packets.properties import PubAckProperties, PublishProperties
+from zmqtt._internal.packets.properties import PublishProperties
 from zmqtt._internal.packets.publish import PubAck, Publish, PubRec, PubRel
 from zmqtt._internal.packets.reader import PacketBuffer
 from zmqtt._internal.packets.subscribe import SubAck, Subscribe, SubscriptionRequest
@@ -23,7 +23,6 @@ from zmqtt._internal.protocol import (
     _PUBLISH_REASON_NAMES,
     MQTTProtocol,
     _raise_on_rejected_filters,
-    _raise_on_rejected_puback,
 )
 from zmqtt._internal.state import SessionState
 from zmqtt._internal.subscription_index import SubscriptionEntry
@@ -595,81 +594,6 @@ async def test_inbound_qos2_manual_ack_duplicate_ignored() -> None:
 
     assert queue.empty()
 
-    await _stop_task(read_task)
-
-
-@pytest.mark.parametrize("reason_code", [0x00, 0x10])
-async def test_publish_qos1_accepted_puback_returns_ack(reason_code: int) -> None:
-    """0x00 and 0x10 (No matching subscribers) are successes: publish() returns the PubAck."""
-    protocol, transport = make_protocol(version="5.0")
-    transport.feed(encode(ConnAck(session_present=False, return_code=0), version="5.0"))
-    await protocol.connect(Connect(client_id="c", clean_session=True, keepalive=60))
-    read_task = await _run_read_loop(protocol)
-    publish_task = asyncio.create_task(
-        protocol.publish(
-            Publish(topic="t/x", payload=b"payload", qos=QoS.AT_LEAST_ONCE, retain=False, dup=False, packet_id=0),
-        ),
-    )
-    await asyncio.sleep(0)
-    pid = next(iter(protocol._state.inflight_qos1))
-
-    transport.feed(encode(PubAck(packet_id=pid, reason_code=reason_code), version="5.0"))
-    ack = await publish_task
-
-    assert ack == PubAck(packet_id=pid, reason_code=reason_code)
-    assert pid not in protocol._state.inflight_qos1
-    await _stop_task(read_task)
-
-
-def test_puback_failure_with_unknown_error_code_sets_reason_name_none() -> None:
-    puback = PubAck(packet_id=1, reason_code=0xFF)
-
-    with pytest.raises(MQTTPublishError) as exc_info:
-        _raise_on_rejected_puback(puback)
-
-    assert exc_info.value.reason_code == 0xFF
-    assert exc_info.value.reason_name is None
-
-
-def test_puback_failure_preserves_broker_reason_string() -> None:
-    puback = PubAck(
-        packet_id=1,
-        reason_code=0x87,
-        properties=PubAckProperties(reason_string="acl denied"),
-    )
-
-    with pytest.raises(MQTTPublishError) as exc_info:
-        _raise_on_rejected_puback(puback)
-
-    assert exc_info.value.reason_name == "Not authorized"
-    assert exc_info.value.reason_string == "acl denied"
-    assert str(exc_info.value) == "Broker rejected publish (0x87 Not authorized): acl denied"
-
-
-@pytest.mark.parametrize("reason_code", PUBLISH_FAILURE_CODES)
-async def test_publish_qos1_rejected_puback_raises_and_releases_packet_id(reason_code: int) -> None:
-    """publish() raises MQTTPublishError on a rejected PUBACK and frees the packet_id."""
-    protocol, transport = make_protocol(version="5.0")
-    transport.feed(encode(ConnAck(session_present=False, return_code=0), version="5.0"))
-    await protocol.connect(Connect(client_id="c", clean_session=True, keepalive=60))
-    transport.sent.clear()
-    read_task = await _run_read_loop(protocol)
-    publish_task = asyncio.create_task(
-        protocol.publish(
-            Publish(topic="t/x", payload=b"payload", qos=QoS.AT_LEAST_ONCE, retain=False, dup=False, packet_id=0),
-        ),
-    )
-    await asyncio.sleep(0)
-    pid = next(iter(protocol._state.inflight_qos1))
-
-    transport.feed(encode(PubAck(packet_id=pid, reason_code=reason_code), version="5.0"))
-    with pytest.raises(MQTTPublishError) as exc_info:
-        await publish_task
-
-    assert exc_info.value.reason_code == reason_code
-    assert exc_info.value.reason_name == _PUBLISH_REASON_NAMES[reason_code]
-    assert pid not in protocol._state.inflight_qos1
-    assert protocol._state.packet_ids.acquire() == pid  # proves release: id is reused
     await _stop_task(read_task)
 
 


### PR DESCRIPTION
## Summary
Raise MQTTPublishError on negative PUBACK/PUBREC reason codes. Fixes #65 
Note: i also added .vscode to gitignore cause it's a common thing created by vscode for many devs

BREAKING CHANGE: On MQTT 5.0, a QoS 1/2 publish rejected by the broker (PUBACK/PUBREC reason code >= 0x80) now raises MQTTPublishError instead of returning normally. MQTT 3.1.1 and QoS 0 are unchanged.

## Validation

<!-- Which checks did you run? -->

- [x] Tests were added or updated when behavior changed
- [x] Documentation was updated when the public API changed
- [x] The PR title follows Conventional Commits, for example `feat(client): add reconnect timeout`
