### PR TITLE
feat(client): expose MQTT connection information

### DIFF
--- a/docs/advanced/mqtt5.md
+++ b/docs/advanced/mqtt5.md
@@ -15,51 +15,37 @@ The return type is `MQTTClientV5`, which exposes 5.0-specific methods and accept
 
 ## Connection information
 
-`client.connection_info` is a read-only `ConnectionInfo | None` property on all
-client types, including MQTT 3.1.1. After a successful handshake it holds an
-immutable snapshot:
+`client.connection_info` returns an immutable `ConnectionInfo` snapshot of the
+current successful handshake on all client types, including MQTT 3.1.1:
 
 ```python
 async with create_client("localhost", version="5.0") as client:
     info = client.connection_info
-    if info is not None:
-        print(info.connection_id, info.session_present, info.return_code)
-        print(info.effective_client_id, info.effective_keepalive)
-        print(info.effective_session_expiry_interval)
-        if info.properties is not None:
-            print(info.properties.response_information)
-            for key, value in info.properties.user_properties:
-                print(key, value)
+    print(info.connection_id, info.session_present)
+    print(info.effective_client_id, info.effective_keepalive)
+    print(info.effective_session_expiry_interval)
+    if info.properties is not None:
+        print(info.properties.response_information)
+        print(info.properties.user_properties)
 ```
 
-`properties` contains the received `ConnAckProperties` without defaults, or
-`None` if none were received. Repeated User Properties keep their wire order.
-Both the snapshot and its nested properties are immutable.
+`properties` holds raw `ConnAckProperties` without defaults, or `None` when
+absent. Repeated User Properties retain their order. Effective values use the
+broker's Assigned Client Identifier when CONNECT sent an empty ID, Server Keep
+Alive over CONNECT's keepalive, and CONNACK session expiry over CONNECT's expiry
+(default `0`). Explicit zero values are preserved; MQTT 3.1.1 has no properties
+or session expiry. See the [MQTT 5.0 specification, CONNACK properties](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901086).
 
-Effective Client ID is the ID sent in CONNECT, or Assigned Client Identifier
-when the sent ID was empty. It stays empty if the broker omits the assignment.
-Effective Keep Alive uses Server Keep Alive when present, otherwise CONNECT's
-value. Effective Session Expiry Interval uses CONNACK's value, then CONNECT's
-value, then `0`; an explicit broker value of `0` is preserved. MQTT 3.1.1 exposes
-`None` for properties and effective session expiry.
+Access raises `MQTTDisconnectedError` before connecting, during retries, and
+after disconnection or background-loop failure. Each successful handshake gets
+a new `connection_id`, starting at 1, even when the MQTT session resumes.
+Failed attempts do not increment it; saved snapshots remain unchanged.
+Subscription restoration may still be running when the snapshot becomes available.
 
-The property is `None` before connecting, after a detected disconnection, during
-retries, and after shutdown or background-loop failure. Each successful network
-connection increments `connection_id`, starting at 1, even if the MQTT session
-resumes. Failed attempts do not increment it. Saved snapshots remain unchanged.
-A snapshot means the handshake succeeded; subscription restoration may still
-be running.
-
-The effective values describe negotiation. Applying Server Keep Alive to ping
-scheduling is tracked in [#77](https://github.com/faststream-community/zMQTT/issues/77),
-and reusing the assigned ID on later CONNECT packets in
-[#79](https://github.com/faststream-community/zMQTT/issues/79).
-Broker limits exposed here are not automatically enforced.
-
-Response Information is available as the raw string
-`info.properties.response_information`; it does not change reply topics or
-`request()`. Requesting it through CONNECT requires the configuration API tracked
-in [#82](https://github.com/faststream-community/zMQTT/issues/82).
+Effective values describe negotiation; they do not change ping scheduling,
+future CONNECT IDs, or enforce broker limits. Response Information is the raw
+broker string and does not alter reply topics or `request()`. Requesting it in
+CONNECT is not currently exposed by the client configuration.
 
 ## Session expiry interval
 

--- a/docs/advanced/mqtt5.md
+++ b/docs/advanced/mqtt5.md
@@ -13,6 +13,54 @@ async with create_client("localhost", version="5.0") as client:
 
 The return type is `MQTTClientV5`, which exposes 5.0-specific methods and accepts 5.0-specific parameters.
 
+## Connection information
+
+`client.connection_info` is a read-only `ConnectionInfo | None` property on all
+client types, including MQTT 3.1.1. After a successful handshake it holds an
+immutable snapshot:
+
+```python
+async with create_client("localhost", version="5.0") as client:
+    info = client.connection_info
+    if info is not None:
+        print(info.connection_id, info.session_present, info.return_code)
+        print(info.effective_client_id, info.effective_keepalive)
+        print(info.effective_session_expiry_interval)
+        if info.properties is not None:
+            print(info.properties.response_information)
+            for key, value in info.properties.user_properties:
+                print(key, value)
+```
+
+`properties` contains the received `ConnAckProperties` without defaults, or
+`None` if none were received. Repeated User Properties keep their wire order.
+Both the snapshot and its nested properties are immutable.
+
+Effective Client ID is the ID sent in CONNECT, or Assigned Client Identifier
+when the sent ID was empty. It stays empty if the broker omits the assignment.
+Effective Keep Alive uses Server Keep Alive when present, otherwise CONNECT's
+value. Effective Session Expiry Interval uses CONNACK's value, then CONNECT's
+value, then `0`; an explicit broker value of `0` is preserved. MQTT 3.1.1 exposes
+`None` for properties and effective session expiry.
+
+The property is `None` before connecting, after a detected disconnection, during
+retries, and after shutdown or background-loop failure. Each successful network
+connection increments `connection_id`, starting at 1, even if the MQTT session
+resumes. Failed attempts do not increment it. Saved snapshots remain unchanged.
+A snapshot means the handshake succeeded; subscription restoration may still
+be running.
+
+The effective values describe negotiation. Applying Server Keep Alive to ping
+scheduling is tracked in [#77](https://github.com/faststream-community/zMQTT/issues/77),
+and reusing the assigned ID on later CONNECT packets in
+[#79](https://github.com/faststream-community/zMQTT/issues/79).
+Broker limits exposed here are not automatically enforced.
+
+Response Information is available as the raw string
+`info.properties.response_information`; it does not change reply topics or
+`request()`. Requesting it through CONNECT requires the configuration API tracked
+in [#82](https://github.com/faststream-community/zMQTT/issues/82).
+
 ## Session expiry interval
 
 Controls how long the broker preserves your session after disconnect. `0` (default) means the session ends immediately on disconnect; `0xFFFFFFFF` means the session never expires.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -45,6 +45,10 @@
         - properties
         - ack
 
+::: zmqtt.ConnectionInfo
+    options:
+      show_source: false
+
 ## Configuration
 
 ::: zmqtt.client.ReconnectConfig
@@ -74,6 +78,10 @@
 ## Properties (MQTT 5.0)
 
 ::: zmqtt.PublishProperties
+    options:
+      show_source: false
+
+::: zmqtt.ConnAckProperties
     options:
       show_source: false
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -44,6 +44,26 @@ except MQTTConnectError as e:
     print(f"Broker refused connection: code {e.return_code}")
 ```
 
+For MQTT 5.0, `e.properties` contains the received `ConnAckProperties`.
+Convenience attributes expose the broker's diagnostics:
+
+```python
+try:
+    async with create_client("localhost", version="5.0") as client:
+        ...
+except MQTTConnectError as e:
+    print(e.return_code, e.reason_string, e.server_reference)
+    for key, value in e.user_properties:
+        print(key, value)
+```
+
+Without properties (including MQTT 3.1.1), `properties`, `reason_string`, and
+`server_reference` are `None`, and `user_properties` is `()`. Repeated User
+Properties preserve their original order. The positional constructor
+`MQTTConnectError(return_code)` and exception text remain unchanged; properties
+can also be supplied with the optional keyword argument `properties=...`.
+A refused connection does not publish `client.connection_info`.
+
 Common return codes (MQTT 3.1.1):
 
 | Code | Meaning |

--- a/src/zmqtt/__init__.py
+++ b/src/zmqtt/__init__.py
@@ -1,10 +1,17 @@
 from zmqtt._internal.packets.connect import Will
-from zmqtt._internal.packets.properties import AuthProperties, ConnectProperties, PublishProperties, WillProperties
+from zmqtt._internal.packets.properties import (
+    AuthProperties,
+    ConnAckProperties,
+    ConnectProperties,
+    PublishProperties,
+    WillProperties,
+)
 from zmqtt._internal.topic_matching import topic_matches
 from zmqtt._internal.types.message import Message
 from zmqtt._internal.types.qos import QoS
 from zmqtt._internal.types.retain_handling import RetainHandling
 from zmqtt.client import (
+    ConnectionInfo,
     MQTTClient,
     MQTTClientV5,
     MQTTClientV311,
@@ -25,7 +32,9 @@ from zmqtt.errors import (
 
 __all__ = (
     "AuthProperties",
+    "ConnAckProperties",
     "ConnectProperties",
+    "ConnectionInfo",
     "MQTTClient",
     "MQTTClientV5",
     "MQTTClientV311",

--- a/src/zmqtt/_internal/protocol.py
+++ b/src/zmqtt/_internal/protocol.py
@@ -199,7 +199,7 @@ class MQTTProtocol:
                     msg = f"Expected CONNACK, got {pkt!r}"
                     raise MQTTProtocolError(msg)
                 if pkt.return_code != 0:
-                    raise MQTTConnectError(pkt.return_code)
+                    raise MQTTConnectError(pkt.return_code, properties=pkt.properties)
                 log.info("Connected with session_present=%s", pkt.session_present)
                 self.inbound.begin_session(session_present=pkt.session_present)
                 return pkt

--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -12,7 +12,7 @@ from typing import Final, Literal, Protocol, overload
 
 from zmqtt._internal._compat import Self, defer_cancellation
 from zmqtt._internal.packets.auth import Auth
-from zmqtt._internal.packets.connect import Connect, Will
+from zmqtt._internal.packets.connect import ConnAck, Connect, Will
 from zmqtt._internal.packets.properties import (
     AuthProperties,
     ConnAckProperties,
@@ -77,6 +77,41 @@ class ConnectionInfo:
     effective_keepalive: int
     effective_session_expiry_interval: int | None
 
+    @classmethod
+    def from_connack(
+        cls,
+        connect_packet: Connect,
+        connack: ConnAck,
+        *,
+        version: Literal["3.1.1", "5.0"],
+        connection_id: int,
+    ) -> Self:
+        """Build a snapshot from a successful CONNECT/CONNACK exchange."""
+        properties = connack.properties
+        client_id = connect_packet.client_id
+        keepalive = connect_packet.keepalive
+        expiry = None
+        if version == "5.0":
+            expiry = 0
+            if connect_packet.properties is not None and connect_packet.properties.session_expiry_interval is not None:
+                expiry = connect_packet.properties.session_expiry_interval
+        if properties is not None:
+            if not client_id and properties.assigned_client_identifier is not None:
+                client_id = properties.assigned_client_identifier
+            if properties.server_keep_alive is not None:
+                keepalive = properties.server_keep_alive
+            if version == "5.0" and properties.session_expiry_interval is not None:
+                expiry = properties.session_expiry_interval
+        return cls(
+            connection_id=connection_id,
+            session_present=connack.session_present,
+            return_code=connack.return_code,
+            properties=properties,
+            effective_client_id=client_id,
+            effective_keepalive=keepalive,
+            effective_session_expiry_interval=expiry,
+        )
+
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class ReconnectConfig:
@@ -134,7 +169,7 @@ class MQTTClientV311(Protocol):
     ) -> "Subscription": ...
 
     @property
-    def connection_info(self) -> ConnectionInfo | None: ...
+    def connection_info(self) -> ConnectionInfo: ...
 
     async def connect(self) -> None: ...
 
@@ -150,7 +185,7 @@ class MQTTClientV5(Protocol):
     async def __aexit__(self, *exc: object) -> None: ...
 
     @property
-    def connection_info(self) -> ConnectionInfo | None: ...
+    def connection_info(self) -> ConnectionInfo: ...
 
     async def connect(self) -> None: ...
 
@@ -466,13 +501,20 @@ class MQTTClient:
         self._subscription_failure: asyncio.Future[BaseException] | None = None
 
     @property
-    def connection_info(self) -> ConnectionInfo | None:
-        """Current successful handshake, or None while disconnected/retrying.
+    def connection_info(self) -> ConnectionInfo:
+        """Current successful handshake.
 
         Subscription restoration may still be in progress. Previously returned
         snapshots remain valid after disconnection. Effective values describe
         negotiation; they do not change ping scheduling or future CONNECT IDs.
+
+        Raises:
+            MQTTDisconnectedError: If no successful connection is active,
+                including before connecting and during reconnection.
         """
+        if self._connection_info is None:
+            msg = "No active connection information"
+            raise MQTTDisconnectedError(msg)
         return self._connection_info
 
     async def __aenter__(self) -> Self:
@@ -806,29 +848,11 @@ class MQTTClient:
         except BaseException:
             await transport.close()
             raise
-        properties = connack.properties
-        client_id = connect_packet.client_id
-        keepalive = connect_packet.keepalive
-        expiry = None
-        if self._version == "5.0":
-            expiry = 0
-            if connect_packet.properties is not None and connect_packet.properties.session_expiry_interval is not None:
-                expiry = connect_packet.properties.session_expiry_interval
-        if properties is not None:
-            if not client_id and properties.assigned_client_identifier is not None:
-                client_id = properties.assigned_client_identifier
-            if properties.server_keep_alive is not None:
-                keepalive = properties.server_keep_alive
-            if self._version == "5.0" and properties.session_expiry_interval is not None:
-                expiry = properties.session_expiry_interval
-        info = ConnectionInfo(
+        info = ConnectionInfo.from_connack(
+            connect_packet,
+            connack,
+            version=self._version,
             connection_id=self._connection_id + 1,
-            session_present=connack.session_present,
-            return_code=connack.return_code,
-            properties=properties,
-            effective_client_id=client_id,
-            effective_keepalive=keepalive,
-            effective_session_expiry_interval=expiry,
         )
         self._protocol = protocol
         self._connection_info = info

--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -15,6 +15,7 @@ from zmqtt._internal.packets.auth import Auth
 from zmqtt._internal.packets.connect import Connect, Will
 from zmqtt._internal.packets.properties import (
     AuthProperties,
+    ConnAckProperties,
     ConnectProperties,
     PublishProperties,
 )
@@ -34,6 +35,7 @@ from zmqtt._internal.types.topic import validate_publish, validate_response_topi
 from zmqtt.errors import MQTTConnectError, MQTTDisconnectedError, MQTTTimeoutError
 
 __all__ = (
+    "ConnectionInfo",
     "MQTTClient",
     "MQTTClientV5",
     "MQTTClientV311",
@@ -49,6 +51,31 @@ TransportFactory = Callable[[str, int, ssl.SSLContext | bool | None], Awaitable[
 _MAX_SUBSCRIPTION_IDENTIFIER = 268_435_455
 
 log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ConnectionInfo:
+    """Immutable snapshot of a successful CONNECT/CONNACK handshake.
+
+    Attributes:
+        connection_id: Successful network connection number within this client,
+            starting at 1. A resumed MQTT session still gets a new number.
+        session_present: Whether the broker resumed an existing MQTT session.
+        return_code: Successful CONNACK return code (0).
+        properties: Raw CONNACK properties, without substituted defaults.
+        effective_client_id: Sent client ID, or the broker-assigned ID if empty.
+        effective_keepalive: Server Keep Alive, falling back to CONNECT keepalive.
+        effective_session_expiry_interval: CONNACK session expiry, falling back
+            to CONNECT and then 0. None for MQTT 3.1.1.
+    """
+
+    connection_id: int
+    session_present: bool
+    return_code: int
+    properties: ConnAckProperties | None
+    effective_client_id: str
+    effective_keepalive: int
+    effective_session_expiry_interval: int | None
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -106,6 +133,9 @@ class MQTTClientV311(Protocol):
         receive_buffer_size: int = 1000,
     ) -> "Subscription": ...
 
+    @property
+    def connection_info(self) -> ConnectionInfo | None: ...
+
     async def connect(self) -> None: ...
 
     async def disconnect(self) -> None: ...
@@ -118,6 +148,9 @@ class MQTTClientV5(Protocol):
 
     async def __aenter__(self) -> Self: ...
     async def __aexit__(self, *exc: object) -> None: ...
+
+    @property
+    def connection_info(self) -> ConnectionInfo | None: ...
 
     async def connect(self) -> None: ...
 
@@ -425,10 +458,22 @@ class MQTTClient:
         self._request_dispatcher = _RequestDispatcher(max_pending_requests)
         self._session_replay_buffer_size = session_replay_buffer_size
         self._session_replay_timeout = session_replay_timeout
+        self._connection_info: ConnectionInfo | None = None
+        self._connection_id = 0
         self._protocol: MQTTProtocol | None = None
         self._subscriptions: list[Subscription] = []
         self._run_task: asyncio.Task[None] | None = None
         self._subscription_failure: asyncio.Future[BaseException] | None = None
+
+    @property
+    def connection_info(self) -> ConnectionInfo | None:
+        """Current successful handshake, or None while disconnected/retrying.
+
+        Subscription restoration may still be in progress. Previously returned
+        snapshots remain valid after disconnection. Effective values describe
+        negotiation; they do not change ping scheduling or future CONNECT IDs.
+        """
+        return self._connection_info
 
     async def __aenter__(self) -> Self:
         """Connect to the broker and start the background run loop."""
@@ -440,6 +485,7 @@ class MQTTClient:
 
     def _notify_subscription_failure(self, run_task: asyncio.Task[None]) -> None:
         """Wake subscription consumers if the client run loop failed."""
+        self._connection_info = None
         if run_task.cancelled():
             return
         failure = run_task.exception()
@@ -449,6 +495,7 @@ class MQTTClient:
 
     async def __aexit__(self, *exc: object) -> None:
         """Disconnect cleanly and cancel the run loop."""
+        self._connection_info = None
         async with defer_cancellation():
             await self._request_dispatcher.cancel_pending()
             if self._run_task is not None:
@@ -755,11 +802,37 @@ class MQTTClient:
             properties=connect_props,
         )
         try:
-            await protocol.connect(connect_packet)
+            connack = await protocol.connect(connect_packet)
         except BaseException:
             await transport.close()
             raise
+        properties = connack.properties
+        client_id = connect_packet.client_id
+        keepalive = connect_packet.keepalive
+        expiry = None
+        if self._version == "5.0":
+            expiry = 0
+            if connect_packet.properties is not None and connect_packet.properties.session_expiry_interval is not None:
+                expiry = connect_packet.properties.session_expiry_interval
+        if properties is not None:
+            if not client_id and properties.assigned_client_identifier is not None:
+                client_id = properties.assigned_client_identifier
+            if properties.server_keep_alive is not None:
+                keepalive = properties.server_keep_alive
+            if self._version == "5.0" and properties.session_expiry_interval is not None:
+                expiry = properties.session_expiry_interval
+        info = ConnectionInfo(
+            connection_id=self._connection_id + 1,
+            session_present=connack.session_present,
+            return_code=connack.return_code,
+            properties=properties,
+            effective_client_id=client_id,
+            effective_keepalive=keepalive,
+            effective_session_expiry_interval=expiry,
+        )
         self._protocol = protocol
+        self._connection_info = info
+        self._connection_id = info.connection_id
         self._request_dispatcher.bind(protocol)
 
     async def _connect_with_retry(self, *, wait_before_first_attempt: bool = False) -> None:
@@ -806,6 +879,7 @@ class MQTTClient:
                 await protocol_run_task
 
             except (MQTTDisconnectedError, MQTTTimeoutError):
+                self._connection_info = None
                 if not self._reconnect.enabled:
                     await self._notify_connection_recovery_failed()
                     raise
@@ -814,6 +888,10 @@ class MQTTClient:
                     await self._protocol._transport.close()
             else:
                 return  # clean disconnect — protocol.disconnect() was called
+            finally:
+                self._connection_info = None
+                protocol_run_task.cancel()
+                await asyncio.gather(protocol_run_task, return_exceptions=True)
 
             subs_to_restore = list(self._subscriptions)
             log.warning("Connection lost, reconnecting...")

--- a/src/zmqtt/errors.py
+++ b/src/zmqtt/errors.py
@@ -1,3 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from zmqtt._internal.packets.properties import ConnAckProperties
+
+
 class MQTTError(Exception):
     """Base class for all zmqtt exceptions."""
 
@@ -5,8 +13,12 @@ class MQTTError(Exception):
 class MQTTConnectError(MQTTError):
     """CONNACK returned a non-zero return code."""
 
-    def __init__(self, return_code: int) -> None:
+    def __init__(self, return_code: int, *, properties: ConnAckProperties | None = None) -> None:
         self.return_code = return_code
+        self.properties = properties
+        self.reason_string = properties.reason_string if properties is not None else None
+        self.user_properties = properties.user_properties if properties is not None else ()
+        self.server_reference = properties.server_reference if properties is not None else None
         super().__init__(f"Connection refused: return code {return_code}")
 
 

--- a/src/zmqtt/errors.py
+++ b/src/zmqtt/errors.py
@@ -1,9 +1,4 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from zmqtt._internal.packets.properties import ConnAckProperties
+from zmqtt._internal.packets.properties import ConnAckProperties
 
 
 class MQTTError(Exception):

--- a/tests/test_brokers/_base.py
+++ b/tests/test_brokers/_base.py
@@ -7,8 +7,10 @@ Run with:  pytest -m broker
 import abc
 import asyncio
 import contextlib
+import ssl
 import uuid
 from collections.abc import AsyncGenerator
+from dataclasses import FrozenInstanceError
 from typing import ClassVar, Literal
 
 import pytest
@@ -24,7 +26,10 @@ from zmqtt import (
     Subscription,
     Will,
     WillProperties,
+    create_client,
 )
+from zmqtt._internal.transport.base import Transport
+from zmqtt._internal.transport.tcp import open_tcp
 
 
 @pytest.mark.broker
@@ -532,6 +537,8 @@ class BrokerTestBase(abc.ABC):
 
             with pytest.raises(MQTTDisconnectedError):
                 await asyncio.wait_for(message_task, timeout=5.0)
+            with pytest.raises(MQTTDisconnectedError, match="No active connection information"):
+                _ = client.connection_info
 
     async def test_on_connection_recovery_failed_called(self) -> None:
         callback_calls = 0
@@ -539,6 +546,8 @@ class BrokerTestBase(abc.ABC):
         async def on_connection_recovery_failed() -> None:
             nonlocal callback_calls
             callback_calls += 1
+            with pytest.raises(MQTTDisconnectedError, match="No active connection information"):
+                _ = client.connection_info
 
         client = MQTTClient(
             self.host,
@@ -676,18 +685,91 @@ class BrokerTestBase(abc.ABC):
         assert msg.payload == b"ack-twice"
 
     async def test_manual_connect_disconnect(self) -> None:
+        client_id = f"zmqtt-manual-{uuid.uuid4().hex[:8]}"
+        client = create_client(
+            self.host,
+            self.port,
+            client_id=client_id,
+            version=self.version,
+        )
+        with pytest.raises(MQTTDisconnectedError, match="No active connection information"):
+            _ = client.connection_info
+        for connection_id in (1, 2):
+            await client.connect()
+            try:
+                info = client.connection_info
+                assert info.connection_id == connection_id
+                assert info.return_code == 0
+                assert not info.session_present
+                assert info.effective_client_id == client_id
+                assert info.effective_keepalive == 60
+                assert info.effective_session_expiry_interval == (0 if self.version == "5.0" else None)
+                if self.version == "3.1.1":
+                    assert info.properties is None
+                with pytest.raises(FrozenInstanceError):
+                    info.connection_id = 100  # type: ignore[misc]
+                with pytest.raises(AttributeError):
+                    client.connection_info = info  # type: ignore[misc]
+                rtt = await client.ping()
+                assert rtt >= 0
+            finally:
+                await client.disconnect()
+            with pytest.raises(MQTTDisconnectedError, match="No active connection information"):
+                _ = client.connection_info
+            assert info.connection_id == connection_id
+
+    async def test_connection_info_reconnect_after_failed_attempt(self, topic: str) -> None:
+        attempts = 0
+        retry_entered = asyncio.Event()
+        allow_retry = asyncio.Event()
+        client_id = f"zmqtt-info-{uuid.uuid4().hex[:8]}"
+
+        async def factory(host: str, port: int, tls: ssl.SSLContext | bool | None) -> Transport:  # noqa: ARG001
+            nonlocal attempts
+            attempts += 1
+            with pytest.raises(MQTTDisconnectedError, match="No active connection information"):
+                _ = client.connection_info
+            if attempts == 2:
+                retry_entered.set()
+                await allow_retry.wait()
+                msg = "temporary connection failure"
+                raise OSError(msg)
+            return await open_tcp(host, port)
+
         client = MQTTClient(
             self.host,
             self.port,
-            client_id=f"zmqtt-manual-{uuid.uuid4().hex[:8]}",
             version=self.version,
+            client_id=client_id,
+            transport_factory=factory,
+            reconnect=ReconnectConfig(initial_delay=0, max_attempts=2),
         )
-        await client.connect()
-        try:
-            rtt = await client.ping()
-            assert rtt >= 0
-        finally:
-            await client.disconnect()
+        async with client, client.subscribe(topic) as subscription:
+            old = client.connection_info
+            await self.force_tcp_disconnect(client)
+            await asyncio.wait_for(retry_entered.wait(), timeout=5)
+            with pytest.raises(MQTTDisconnectedError, match="No active connection information"):
+                _ = client.connection_info
+            allow_retry.set()
+
+            # A delivered message proves both handshake and subscription recovery.
+            async with MQTTClient(self.host, self.port, version=self.version) as publisher:
+                for _ in range(50):
+                    await publisher.publish(topic, b"reconnected")
+                    try:
+                        message = await asyncio.wait_for(subscription.get_message(), timeout=0.1)
+                    except asyncio.TimeoutError:
+                        continue
+                    break
+                else:
+                    pytest.fail("Subscription did not recover within 5 s")
+            assert message.payload == b"reconnected"
+            new = client.connection_info
+            assert new.connection_id == 2
+            assert new is not old
+            assert old.connection_id == 1
+            assert new.effective_client_id == old.effective_client_id == client_id
+            assert attempts == 3
 
     async def test_context_manager_manual_pub_sub(self, topic: str) -> None:
         async with MQTTClient(

--- a/tests/test_brokers/_base.py
+++ b/tests/test_brokers/_base.py
@@ -696,24 +696,22 @@ class BrokerTestBase(abc.ABC):
             _ = client.connection_info
         for connection_id in (1, 2):
             await client.connect()
-            try:
-                info = client.connection_info
-                assert info.connection_id == connection_id
-                assert info.return_code == 0
-                assert not info.session_present
-                assert info.effective_client_id == client_id
-                assert info.effective_keepalive == 60
-                assert info.effective_session_expiry_interval == (0 if self.version == "5.0" else None)
-                if self.version == "3.1.1":
-                    assert info.properties is None
-                with pytest.raises(FrozenInstanceError):
-                    info.connection_id = 100  # type: ignore[misc]
-                with pytest.raises(AttributeError):
-                    client.connection_info = info  # type: ignore[misc]
-                rtt = await client.ping()
-                assert rtt >= 0
-            finally:
-                await client.disconnect()
+            info = client.connection_info
+            assert info.connection_id == connection_id
+            assert info.return_code == 0
+            assert not info.session_present
+            assert info.effective_client_id == client_id
+            assert info.effective_keepalive == 60
+            assert info.effective_session_expiry_interval == (0 if self.version == "5.0" else None)
+            if self.version == "3.1.1":
+                assert info.properties is None
+            with pytest.raises(FrozenInstanceError):
+                info.connection_id = 100  # type: ignore[misc]
+            with pytest.raises(AttributeError):
+                client.connection_info = info  # type: ignore[misc]
+            rtt = await client.ping()
+            assert rtt >= 0
+            await client.disconnect()
             with pytest.raises(MQTTDisconnectedError, match="No active connection information"):
                 _ = client.connection_info
             assert info.connection_id == connection_id

--- a/tests/test_connection_info.py
+++ b/tests/test_connection_info.py
@@ -1,0 +1,326 @@
+"""Public handshake snapshots exercised through the real MQTT protocol."""
+
+import asyncio
+import ssl
+from collections.abc import Callable
+from dataclasses import FrozenInstanceError
+from typing import Literal
+
+import pytest
+
+from tests.test_protocol import FakeTransport
+from zmqtt import (
+    ConnAckProperties,
+    ConnectionInfo,
+    MQTTClient,
+    MQTTClientV5,
+    MQTTClientV311,
+    MQTTConnectError,
+    MQTTDisconnectedError,
+    MQTTTimeoutError,
+    ReconnectConfig,
+    create_client,
+)
+from zmqtt._internal.packets.codec import encode
+from zmqtt._internal.packets.connect import ConnAck, Connect
+from zmqtt._internal.packets.reader import PacketBuffer
+from zmqtt._internal.transport.base import Transport
+from zmqtt.client import TransportFactory
+
+
+def transport_factory(transport: FakeTransport) -> TransportFactory:
+    async def factory(host: str, port: int, tls: ssl.SSLContext | bool | None) -> Transport:  # noqa: ARG001
+        return transport
+
+    return factory
+
+
+def assert_disconnected(client: MQTTClientV311 | MQTTClientV5) -> None:
+    assert client.connection_info is None
+
+
+async def wait_until(predicate: Callable[[], bool]) -> None:
+    async def wait() -> None:
+        while not predicate():  # noqa: ASYNC110
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(wait(), timeout=2)
+
+
+async def test_full_connack_snapshot_is_immutable() -> None:
+    properties = ConnAckProperties(
+        session_expiry_interval=120,
+        receive_maximum=12,
+        maximum_qos=1,
+        retain_available=False,
+        maximum_packet_size=4096,
+        assigned_client_identifier="broker-id",
+        topic_alias_maximum=8,
+        reason_string="welcome",
+        wildcard_subscription_available=False,
+        subscription_identifier_available=True,
+        shared_subscription_available=False,
+        server_keep_alive=30,
+        response_information="reply-prefix/raw",
+        server_reference="broker.example",
+        authentication_method="example",
+        authentication_data=b"data",
+        user_properties=(("key", "first"), ("key", "second")),
+    )
+    transport = FakeTransport()
+    transport.feed(encode(ConnAck(session_present=True, return_code=0, properties=properties), version="5.0"))
+    client = create_client("localhost", version="5.0", transport_factory=transport_factory(transport))
+    assert_disconnected(client)
+    async with client:
+        info = client.connection_info
+        assert info == ConnectionInfo(
+            connection_id=1,
+            session_present=True,
+            return_code=0,
+            properties=properties,
+            effective_client_id="broker-id",
+            effective_keepalive=30,
+            effective_session_expiry_interval=120,
+        )
+        assert info is not None
+        assert info.properties is not None
+        with pytest.raises(FrozenInstanceError):
+            info.connection_id = 2  # type: ignore[misc]
+        with pytest.raises(FrozenInstanceError):
+            info.properties.reason_string = "changed"  # type: ignore[misc]
+        with pytest.raises(TypeError):
+            info.properties.user_properties[0][0] = "changed"  # type: ignore[index]
+        with pytest.raises(AttributeError):
+            client.connection_info = None  # type: ignore[misc]
+    assert_disconnected(client)
+    assert info.properties == properties
+
+
+@pytest.mark.parametrize("version", ["3.1.1", "5.0"])
+@pytest.mark.parametrize("client_id", ["", "explicit"])
+@pytest.mark.parametrize("expiry", [0, 600])
+@pytest.mark.parametrize(
+    "properties",
+    [
+        None,
+        ConnAckProperties(),
+        ConnAckProperties(reason_string="welcome"),
+        ConnAckProperties(server_keep_alive=0, session_expiry_interval=0),
+    ],
+)
+async def test_connection_info_fallbacks(
+    version: Literal["3.1.1", "5.0"], client_id: str, expiry: int, properties: ConnAckProperties | None
+) -> None:
+    transport = FakeTransport()
+    transport.feed(encode(ConnAck(session_present=False, return_code=0, properties=properties), version=version))
+    client = MQTTClient(
+        "localhost",
+        version=version,
+        client_id=client_id,
+        keepalive=45,
+        session_expiry_interval=expiry,
+        transport_factory=transport_factory(transport),
+    )
+    async with client:
+        info = client.connection_info
+        assert info is not None
+        assert info.connection_id == 1
+        assert info.effective_client_id == client_id
+        overridden = version == "5.0" and properties is not None and properties.server_keep_alive is not None
+        assert info.effective_keepalive == (0 if overridden else 45)
+        assert info.effective_session_expiry_interval == ((0 if overridden else expiry) if version == "5.0" else None)
+        assert info.properties == (properties if version == "5.0" and properties != ConnAckProperties() else None)
+
+
+async def test_explicit_client_id_takes_precedence() -> None:
+    transport = FakeTransport()
+    transport.feed(
+        encode(
+            ConnAck(
+                session_present=False,
+                return_code=0,
+                properties=ConnAckProperties(assigned_client_identifier="assigned"),
+            ),
+            version="5.0",
+        )
+    )
+    client = create_client(
+        "localhost", version="5.0", client_id="explicit", transport_factory=transport_factory(transport)
+    )
+    async with client:
+        assert client.connection_info is not None
+        assert client.connection_info.effective_client_id == "explicit"
+
+
+async def test_reconnect_replaces_snapshot_after_failed_attempt() -> None:
+    transports = [FakeTransport(), FakeTransport()]
+    for transport in transports:
+        transport.feed(
+            encode(
+                ConnAck(
+                    session_present=True,
+                    return_code=0,
+                    properties=ConnAckProperties(assigned_client_identifier="assigned"),
+                ),
+                version="5.0",
+            )
+        )
+    attempts = 0
+    retry_entered = asyncio.Event()
+    allow_retry = asyncio.Event()
+
+    async def factory(host: str, port: int, tls: ssl.SSLContext | bool | None) -> Transport:  # noqa: ARG001
+        nonlocal attempts
+        attempts += 1
+        if attempts == 2:
+            assert_disconnected(client)
+            retry_entered.set()
+            await allow_retry.wait()
+            msg = "temporary connection failure"
+            raise OSError(msg)
+        assert_disconnected(client)
+        return transports[0 if attempts == 1 else 1]
+
+    client = create_client(
+        "localhost",
+        version="5.0",
+        transport_factory=factory,
+        reconnect=ReconnectConfig(initial_delay=0, max_attempts=2),
+    )
+    async with client:
+        old = client.connection_info
+        assert old is not None
+        transports[0]._rx.append(MQTTDisconnectedError("lost"))
+        await asyncio.wait_for(retry_entered.wait(), timeout=2)
+        assert_disconnected(client)
+        allow_retry.set()
+        await wait_until(lambda: client.connection_info is not None)
+        new = client.connection_info
+        assert new is not None
+        assert new.connection_id == 2
+        assert new is not old
+        assert old.connection_id == 1
+        assert old.effective_client_id == "assigned"
+        assert attempts == 3
+        for transport in transports:
+            buffer = PacketBuffer(version="5.0")
+            buffer.feed(transport.sent[0])
+            packet = next(iter(buffer))
+            assert isinstance(packet, Connect)
+            assert packet.client_id == ""
+    assert_disconnected(client)
+
+
+@pytest.mark.parametrize("failure", [MQTTDisconnectedError("lost"), MQTTTimeoutError("timeout"), ValueError("crashed")])
+async def test_background_failure_clears_snapshot(failure: Exception) -> None:
+    transport = FakeTransport()
+    transport.feed(encode(ConnAck(session_present=False, return_code=0), version="3.1.1"))
+    observed: list[ConnectionInfo | None] = []
+
+    async def callback() -> None:
+        observed.append(client.connection_info)
+
+    client = MQTTClient(
+        "localhost",
+        transport_factory=transport_factory(transport),
+        reconnect=ReconnectConfig(enabled=False),
+        on_connection_recovery_failed=callback,
+    )
+    async with client:
+        assert client.connection_info is not None
+        transport._rx.append(failure)
+        assert client._run_task is not None
+        with pytest.raises(type(failure), match=str(failure)):
+            await asyncio.wait_for(asyncio.shield(client._run_task), timeout=2)
+        assert_disconnected(client)
+        assert observed == ([] if isinstance(failure, ValueError) else [None])
+
+
+@pytest.mark.parametrize("failure", ["refusal", "timeout"])
+async def test_failed_recovery_clears_snapshot_before_callback(failure: str) -> None:
+    first, retry = FakeTransport(), FakeTransport()
+    first.feed(encode(ConnAck(session_present=False, return_code=0), version="5.0"))
+    if failure == "refusal":
+        retry.feed(encode(ConnAck(session_present=False, return_code=0x87), version="5.0"))
+    transports = iter([first, retry])
+    observed: list[ConnectionInfo | None] = []
+
+    async def factory(host: str, port: int, tls: ssl.SSLContext | bool | None) -> Transport:  # noqa: ARG001
+        assert_disconnected(client)
+        return next(transports)
+
+    async def callback() -> None:
+        observed.append(client.connection_info)
+
+    client = MQTTClient(
+        "localhost",
+        version="5.0",
+        transport_factory=factory,
+        mqtt_connect_timeout=0.02,
+        reconnect=ReconnectConfig(initial_delay=0, max_attempts=1),
+        on_connection_recovery_failed=callback,
+    )
+    async with client:
+        first._rx.append(MQTTDisconnectedError("lost"))
+        assert client._run_task is not None
+        with pytest.raises(MQTTConnectError if failure == "refusal" else MQTTTimeoutError):
+            await asyncio.wait_for(asyncio.shield(client._run_task), timeout=2)
+        assert observed == [None]
+        assert_disconnected(client)
+        assert not retry.is_connected
+
+
+@pytest.mark.parametrize(("version", "code"), [("3.1.1", 5), ("5.0", 0x87)])
+async def test_connection_refusal_diagnostics(version: Literal["3.1.1", "5.0"], code: int) -> None:
+    props = (
+        ConnAckProperties(
+            reason_string="denied", server_reference="other.example", user_properties=(("key", "one"), ("key", "two"))
+        )
+        if version == "5.0"
+        else None
+    )
+    transport = FakeTransport()
+    transport.feed(encode(ConnAck(session_present=False, return_code=code, properties=props), version=version))
+    client = MQTTClient("localhost", version=version, transport_factory=transport_factory(transport))
+    with pytest.raises(MQTTConnectError) as caught:
+        await client.connect()
+    error = caught.value
+    assert error.return_code == code
+    assert str(error) == f"Connection refused: return code {code}"
+    assert error.properties == props
+    assert error.reason_string == (props.reason_string if props else None)
+    assert error.server_reference == (props.server_reference if props else None)
+    assert error.user_properties == (props.user_properties if props else ())
+    assert_disconnected(client)
+    assert not transport.is_connected
+    legacy = MQTTConnectError(code)
+    assert legacy.properties is None
+    assert legacy.reason_string is None
+    assert legacy.server_reference is None
+    assert legacy.user_properties == ()
+
+
+async def test_initial_timeout_has_no_snapshot() -> None:
+    transport = FakeTransport()
+    client = create_client(
+        "localhost",
+        transport_factory=transport_factory(transport),
+        mqtt_connect_timeout=0.02,
+        reconnect=ReconnectConfig(enabled=False),
+    )
+    with pytest.raises(MQTTTimeoutError):
+        await client.connect()
+    assert_disconnected(client)
+    assert not transport.is_connected
+
+
+async def test_immediate_disconnect_and_next_connect() -> None:
+    transport = FakeTransport()
+    client = create_client("localhost", transport_factory=transport_factory(transport))
+    for connection_id in (1, 2):
+        transport.feed(encode(ConnAck(session_present=False, return_code=0), version="3.1.1"))
+        await client.connect()
+        assert client.connection_info is not None
+        assert client.connection_info.connection_id == connection_id
+        await client.disconnect()
+        assert_disconnected(client)

--- a/tests/test_connection_info.py
+++ b/tests/test_connection_info.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import ssl
-from collections.abc import Callable
 from dataclasses import FrozenInstanceError
 from typing import Literal
 
@@ -22,8 +21,7 @@ from zmqtt import (
     create_client,
 )
 from zmqtt._internal.packets.codec import encode
-from zmqtt._internal.packets.connect import ConnAck, Connect
-from zmqtt._internal.packets.reader import PacketBuffer
+from zmqtt._internal.packets.connect import ConnAck
 from zmqtt._internal.transport.base import Transport
 from zmqtt.client import TransportFactory
 
@@ -36,15 +34,8 @@ def transport_factory(transport: FakeTransport) -> TransportFactory:
 
 
 def assert_disconnected(client: MQTTClientV311 | MQTTClientV5) -> None:
-    assert client.connection_info is None
-
-
-async def wait_until(predicate: Callable[[], bool]) -> None:
-    async def wait() -> None:
-        while not predicate():  # noqa: ASYNC110
-            await asyncio.sleep(0)
-
-    await asyncio.wait_for(wait(), timeout=2)
+    with pytest.raises(MQTTDisconnectedError, match="No active connection information"):
+        _ = client.connection_info
 
 
 async def test_full_connack_snapshot_is_immutable() -> None:
@@ -91,12 +82,11 @@ async def test_full_connack_snapshot_is_immutable() -> None:
         with pytest.raises(TypeError):
             info.properties.user_properties[0][0] = "changed"  # type: ignore[index]
         with pytest.raises(AttributeError):
-            client.connection_info = None  # type: ignore[misc]
+            client.connection_info = info  # type: ignore[misc]
     assert_disconnected(client)
     assert info.properties == properties
 
 
-@pytest.mark.parametrize("version", ["3.1.1", "5.0"])
 @pytest.mark.parametrize("client_id", ["", "explicit"])
 @pytest.mark.parametrize("expiry", [0, 600])
 @pytest.mark.parametrize(
@@ -108,14 +98,12 @@ async def test_full_connack_snapshot_is_immutable() -> None:
         ConnAckProperties(server_keep_alive=0, session_expiry_interval=0),
     ],
 )
-async def test_connection_info_fallbacks(
-    version: Literal["3.1.1", "5.0"], client_id: str, expiry: int, properties: ConnAckProperties | None
-) -> None:
+async def test_connection_info_fallbacks(client_id: str, expiry: int, properties: ConnAckProperties | None) -> None:
     transport = FakeTransport()
-    transport.feed(encode(ConnAck(session_present=False, return_code=0, properties=properties), version=version))
+    transport.feed(encode(ConnAck(session_present=False, return_code=0, properties=properties), version="5.0"))
     client = MQTTClient(
         "localhost",
-        version=version,
+        version="5.0",
         client_id=client_id,
         keepalive=45,
         session_expiry_interval=expiry,
@@ -126,10 +114,10 @@ async def test_connection_info_fallbacks(
         assert info is not None
         assert info.connection_id == 1
         assert info.effective_client_id == client_id
-        overridden = version == "5.0" and properties is not None and properties.server_keep_alive is not None
+        overridden = properties is not None and properties.server_keep_alive is not None
         assert info.effective_keepalive == (0 if overridden else 45)
-        assert info.effective_session_expiry_interval == ((0 if overridden else expiry) if version == "5.0" else None)
-        assert info.properties == (properties if version == "5.0" and properties != ConnAckProperties() else None)
+        assert info.effective_session_expiry_interval == (0 if overridden else expiry)
+        assert info.properties == (properties if properties != ConnAckProperties() else None)
 
 
 async def test_explicit_client_id_takes_precedence() -> None:
@@ -152,73 +140,15 @@ async def test_explicit_client_id_takes_precedence() -> None:
         assert client.connection_info.effective_client_id == "explicit"
 
 
-async def test_reconnect_replaces_snapshot_after_failed_attempt() -> None:
-    transports = [FakeTransport(), FakeTransport()]
-    for transport in transports:
-        transport.feed(
-            encode(
-                ConnAck(
-                    session_present=True,
-                    return_code=0,
-                    properties=ConnAckProperties(assigned_client_identifier="assigned"),
-                ),
-                version="5.0",
-            )
-        )
-    attempts = 0
-    retry_entered = asyncio.Event()
-    allow_retry = asyncio.Event()
-
-    async def factory(host: str, port: int, tls: ssl.SSLContext | bool | None) -> Transport:  # noqa: ARG001
-        nonlocal attempts
-        attempts += 1
-        if attempts == 2:
-            assert_disconnected(client)
-            retry_entered.set()
-            await allow_retry.wait()
-            msg = "temporary connection failure"
-            raise OSError(msg)
-        assert_disconnected(client)
-        return transports[0 if attempts == 1 else 1]
-
-    client = create_client(
-        "localhost",
-        version="5.0",
-        transport_factory=factory,
-        reconnect=ReconnectConfig(initial_delay=0, max_attempts=2),
-    )
-    async with client:
-        old = client.connection_info
-        assert old is not None
-        transports[0]._rx.append(MQTTDisconnectedError("lost"))
-        await asyncio.wait_for(retry_entered.wait(), timeout=2)
-        assert_disconnected(client)
-        allow_retry.set()
-        await wait_until(lambda: client.connection_info is not None)
-        new = client.connection_info
-        assert new is not None
-        assert new.connection_id == 2
-        assert new is not old
-        assert old.connection_id == 1
-        assert old.effective_client_id == "assigned"
-        assert attempts == 3
-        for transport in transports:
-            buffer = PacketBuffer(version="5.0")
-            buffer.feed(transport.sent[0])
-            packet = next(iter(buffer))
-            assert isinstance(packet, Connect)
-            assert packet.client_id == ""
-    assert_disconnected(client)
-
-
-@pytest.mark.parametrize("failure", [MQTTDisconnectedError("lost"), MQTTTimeoutError("timeout"), ValueError("crashed")])
+@pytest.mark.parametrize("failure", [MQTTTimeoutError("timeout"), ValueError("crashed")])
 async def test_background_failure_clears_snapshot(failure: Exception) -> None:
     transport = FakeTransport()
     transport.feed(encode(ConnAck(session_present=False, return_code=0), version="3.1.1"))
-    observed: list[ConnectionInfo | None] = []
+    observed: list[bool] = []
 
     async def callback() -> None:
-        observed.append(client.connection_info)
+        assert_disconnected(client)
+        observed.append(True)
 
     client = MQTTClient(
         "localhost",
@@ -233,7 +163,7 @@ async def test_background_failure_clears_snapshot(failure: Exception) -> None:
         with pytest.raises(type(failure), match=str(failure)):
             await asyncio.wait_for(asyncio.shield(client._run_task), timeout=2)
         assert_disconnected(client)
-        assert observed == ([] if isinstance(failure, ValueError) else [None])
+        assert observed == ([] if isinstance(failure, ValueError) else [True])
 
 
 @pytest.mark.parametrize("failure", ["refusal", "timeout"])
@@ -243,14 +173,15 @@ async def test_failed_recovery_clears_snapshot_before_callback(failure: str) -> 
     if failure == "refusal":
         retry.feed(encode(ConnAck(session_present=False, return_code=0x87), version="5.0"))
     transports = iter([first, retry])
-    observed: list[ConnectionInfo | None] = []
+    observed: list[bool] = []
 
     async def factory(host: str, port: int, tls: ssl.SSLContext | bool | None) -> Transport:  # noqa: ARG001
         assert_disconnected(client)
         return next(transports)
 
     async def callback() -> None:
-        observed.append(client.connection_info)
+        assert_disconnected(client)
+        observed.append(True)
 
     client = MQTTClient(
         "localhost",
@@ -265,7 +196,7 @@ async def test_failed_recovery_clears_snapshot_before_callback(failure: str) -> 
         assert client._run_task is not None
         with pytest.raises(MQTTConnectError if failure == "refusal" else MQTTTimeoutError):
             await asyncio.wait_for(asyncio.shield(client._run_task), timeout=2)
-        assert observed == [None]
+        assert observed == [True]
         assert_disconnected(client)
         assert not retry.is_connected
 
@@ -312,15 +243,3 @@ async def test_initial_timeout_has_no_snapshot() -> None:
         await client.connect()
     assert_disconnected(client)
     assert not transport.is_connected
-
-
-async def test_immediate_disconnect_and_next_connect() -> None:
-    transport = FakeTransport()
-    client = create_client("localhost", transport_factory=transport_factory(transport))
-    for connection_id in (1, 2):
-        transport.feed(encode(ConnAck(session_present=False, return_code=0), version="3.1.1"))
-        await client.connect()
-        assert client.connection_info is not None
-        assert client.connection_info.connection_id == connection_id
-        await client.disconnect()
-        assert_disconnected(client)


### PR DESCRIPTION
## Summary

Expose a read-only `client.connection_info` snapshot after each successful MQTT handshake. Applications can inspect raw CONNACK properties and negotiated client ID, keepalive, and session expiry through both version-specific client types. The property returns `ConnectionInfo` and raises `MQTTDisconnectedError` when no successful connection is active.

Snapshots are immutable, cleared on disconnect or background-loop failure, and replaced with a new connection ID after successful reconnect. MQTT 5 connection refusals expose properties, reason string, ordered user properties, and server reference without changing the existing exception constructor usage or message.

Export `ConnectionInfo` and `ConnAckProperties`; build snapshots with `ConnectionInfo.from_connack`. Cover ordinary lifecycle behavior in the shared five-broker suite and use controlled transports for specific CONNACK properties and failures. Update the API, MQTT 5, and error documentation. CONNECT configuration, assigned-ID reuse, ping scheduling, and broker-limit enforcement remain separate tasks.

Closes #85.

## Validation

All checks passed after review fixes:

- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run mypy`
- `uv run pytest -vv` — 692 passed, 24 skipped, with all five Docker Compose brokers running
- `uv run mkdocs build --strict`
- `uv build`

- [x] Tests were added or updated when behavior changed
- [x] Documentation was updated when the public API changed
- [x] The PR title follows Conventional Commits
