### PR TITLE
fix(protocol) expose structured metadata from broker DISCONNECT packets

### DIFF
--- a/src/zmqtt/_internal/protocol.py
+++ b/src/zmqtt/_internal/protocol.py
@@ -4,7 +4,7 @@ import asyncio
 import contextlib
 import dataclasses
 import logging
-from collections.abc import AsyncGenerator, Iterable
+from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable
 from typing import Final, Literal
 
 from zmqtt._internal import topic_matching
@@ -172,6 +172,7 @@ class MQTTProtocol:
         self._disconnecting = False
         self._dead = False
         self.started_event = asyncio.Event()
+        self._disconnect_callbacks: list[Callable[[MQTTDisconnectedError], Awaitable[None]]] = []
 
     async def connect(self, packet: Connect) -> ConnAck:
         """Send CONNECT, read and return CONNACK. Raises on failure.
@@ -534,12 +535,11 @@ class MQTTProtocol:
                 await self._handle_unsuback(packet)
             case PingResp():
                 self._handle_pingresp()
-            case Disconnect(reason_code=reason_code):
+            case Disconnect():
                 # A broker-initiated DISCONNECT (session takeover, keepalive timeout,
                 # admin kick) is a disconnection, not a protocol violation — raise it
                 # as MQTTDisconnectedError so it takes the reconnect path.
-                msg = f"Broker sent DISCONNECT (reason code 0x{reason_code:02X})"
-                raise MQTTDisconnectedError(msg)
+                await self._handle_disconnect(packet)
             case Auth():
                 if self._version != "5.0":
                     msg = "Received AUTH packet in MQTT 3.1.1 session"
@@ -551,8 +551,40 @@ class MQTTProtocol:
                 msg = f"Unexpected packet from broker: {packet!r}"
                 raise MQTTProtocolError(msg)
 
+    def add_disconnect_callback(self, callback: Callable[[MQTTDisconnectedError], Awaitable[None]]) -> None:
+        """Register a callback for observing a broker-initiated DISCONNECT"""
+        self._disconnect_callbacks.append(callback)
+
     def _select_recipient(self, publish: Publish) -> InboundRecipient:
         return self.inbound.select_recipient(publish)
+
+    async def _handle_disconnect(self, packet: Disconnect) -> None:
+        """Handle broker-initiated DISCONNECT"""
+        reason_code = packet.reason_code
+        properties = packet.properties
+
+        msg = f"Broker sent DISCONNECT (reason code 0x{reason_code:02X})"
+
+        if self._version == "5.0" and properties:
+            error = MQTTDisconnectedError(
+                msg=msg,
+                reason_code=reason_code,
+                properties=properties,
+                is_broker_disconnected=True,
+            )
+        else:
+            error = MQTTDisconnectedError(
+                msg=msg,
+                reason_code=reason_code,
+                is_broker_disconnected=True,
+            )
+        try:
+            for callback in self._disconnect_callbacks:
+                await callback(error)
+        except Exception:
+            log.exception("Disconnect callback failed")
+
+        raise error
 
     async def _handle_publish(self, packet: Publish) -> None:
         await self.inbound.handle_publish(packet)

--- a/src/zmqtt/errors.py
+++ b/src/zmqtt/errors.py
@@ -1,3 +1,6 @@
+from zmqtt._internal.packets.properties import DisconnectProperties
+
+
 class MQTTError(Exception):
     """Base class for all zmqtt exceptions."""
 
@@ -16,6 +19,22 @@ class MQTTProtocolError(MQTTError):
 
 class MQTTDisconnectedError(MQTTError):
     """Connection lost unexpectedly."""
+
+    def __init__(
+        self,
+        msg: str,
+        reason_code: int | None = None,
+        properties: DisconnectProperties | None = None,
+        *,
+        is_broker_disconnected: bool = False,
+    ) -> None:
+        self.reason_code = reason_code
+        self.properties = properties
+        self.reason_string = properties.reason_string if properties is not None else None
+        self.user_properties = properties.user_properties if properties is not None else ()
+        self.server_reference = properties.server_reference if properties is not None else None
+        self.is_broker_disconnected = is_broker_disconnected
+        super().__init__(msg)
 
 
 class MQTTTimeoutError(MQTTError):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -9,13 +9,14 @@ import contextlib
 import logging
 from collections import deque
 from typing import Literal
+from unittest.mock import AsyncMock
 
 import pytest
 
 from zmqtt._internal.packets.codec import encode
 from zmqtt._internal.packets.connect import ConnAck, Connect
 from zmqtt._internal.packets.disconnect import Disconnect
-from zmqtt._internal.packets.properties import PublishProperties
+from zmqtt._internal.packets.properties import DisconnectProperties, PublishProperties
 from zmqtt._internal.packets.publish import PubAck, Publish, PubRec, PubRel
 from zmqtt._internal.packets.reader import PacketBuffer
 from zmqtt._internal.packets.subscribe import SubAck, Subscribe, SubscriptionRequest
@@ -474,6 +475,94 @@ async def test_broker_disconnect_is_a_disconnection() -> None:
 
     with pytest.raises(MQTTDisconnectedError):
         await asyncio.wait_for(protocol._read_loop(), timeout=1)
+
+
+async def test_disconnect_with_properties_mqtt5() -> None:
+    protocol, _ = make_protocol(version="5.0")
+
+    properties = DisconnectProperties(
+        reason_string="admin kick",
+        server_reference="mqtt2.example.com:1883",
+        user_properties=(
+            ("key1", "value1"),
+            ("key2", "value2"),
+            ("key1", "value3"),
+        ),
+    )
+
+    disconnect = Disconnect(reason_code=0x82, properties=properties)
+
+    with pytest.raises(MQTTDisconnectedError) as ex:
+        await protocol._dispatch(disconnect)
+
+    error = ex.value
+    assert error.is_broker_disconnected is True
+    assert error.reason_code == 0x82
+    assert error.properties is properties
+    assert error.reason_string == "admin kick"
+    assert error.server_reference == "mqtt2.example.com:1883"
+    assert error.user_properties == (
+        ("key1", "value1"),
+        ("key2", "value2"),
+        ("key1", "value3"),
+    )
+
+
+async def test_disconnect_without_properties_mqtt311() -> None:
+    protocol, _ = make_protocol(version="3.1.1")
+
+    disconnect = Disconnect(reason_code=0x00)
+
+    with pytest.raises(MQTTDisconnectedError) as ex:
+        await protocol._dispatch(disconnect)
+
+    error = ex.value
+    assert error.is_broker_disconnected is True
+    assert error.reason_code == 0x00
+    assert error.properties is None
+    assert error.reason_string is None
+    assert error.server_reference is None
+    assert error.user_properties == ()
+
+
+async def test_disconnect_distinguished_from_transport_error() -> None:
+    protocol, _ = make_protocol(version="5.0")
+
+    disconnect = Disconnect(reason_code=0x80)
+    with pytest.raises(MQTTDisconnectedError) as exc_info:
+        await protocol._dispatch(disconnect)
+
+    assert exc_info.value.is_broker_disconnected is True
+    assert exc_info.value.reason_code == 0x80
+
+    with pytest.raises(MQTTDisconnectedError) as exc_info:
+        raise MQTTDisconnectedError(msg="Connection lost")
+
+    assert exc_info.value.is_broker_disconnected is False
+    assert exc_info.value.reason_code is None
+
+
+async def test_disconnect_callback_called_before_raise() -> None:
+    protocol, _ = make_protocol(version="5.0")
+
+    callback = AsyncMock()
+    protocol.add_disconnect_callback(callback)
+
+    properties = DisconnectProperties(
+        reason_string="admin kick", server_reference="mqtt2.example.com:1883", user_properties=(("test", "value"),)
+    )
+    disconnect = Disconnect(reason_code=0x80, properties=properties)
+
+    with pytest.raises(MQTTDisconnectedError):
+        await protocol._dispatch(disconnect)
+
+    callback.assert_awaited_once()
+    error_arg = callback.call_args[0][0]
+    assert error_arg.reason_code == 0x80
+    assert error_arg.reason_string == "admin kick"
+    assert error_arg.server_reference == "mqtt2.example.com:1883"
+    assert error_arg.user_properties == (("test", "value"),)
+    assert error_arg.is_broker_disconnected is True
 
 
 async def test_dead_protocol_refuses_new_operations() -> None:


### PR DESCRIPTION
## Summary

- Broker's metadata on DISCONNECT packet exposed
- DISCONNECT is remain observable even when recconect mode enabled through callback notification system 
- Flag for distinguishing broker DISCONNECT from a transport failure added

## Validation

<!-- Which checks did you run? -->

- [ ] Tests were added or updated when behavior changed
- [ ] Documentation was updated when the public API changed
- [ ] The PR title follows Conventional Commits, for example `feat(client): add reconnect timeout`
