### PR TITLE
fix(client): validate outgoing topic aliases against server limit

### DIFF
--- a/docs/advanced/mqtt5.md
+++ b/docs/advanced/mqtt5.md
@@ -94,7 +94,7 @@ async for msg in sub:
 |-------|------|-------------|
 | `payload_format_indicator` | `int \| None` | 0 = bytes, 1 = UTF-8 string |
 | `message_expiry_interval` | `int \| None` | Seconds until broker discards |
-| `topic_alias` | `int \| None` | Topic alias integer |
+| `topic_alias` | `int \| None` | Integer 1..65535, limited by the server's Topic Alias Maximum |
 | `response_topic` | `str \| None` | Topic for response messages |
 | `correlation_data` | `bytes \| None` | Request/response correlation token |
 | `subscription_identifier` | `int \| None` | Set by broker, not by publisher |

--- a/src/zmqtt/_internal/packets/properties.py
+++ b/src/zmqtt/_internal/packets/properties.py
@@ -253,8 +253,8 @@ class PublishProperties:
             encoded character data.
         message_expiry_interval: Seconds the broker retains the message. Omit to
             keep indefinitely.
-        topic_alias: Topic alias integer used instead of the full topic string on
-            the wire.
+        topic_alias: Topic alias integer (1..65535). Outgoing aliases must not
+            exceed the server's Topic Alias Maximum for the current connection.
         response_topic: Topic the receiver should use when replying
             (request/response pattern).
         correlation_data: Opaque bytes the sender uses to match a response to a

--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -50,6 +50,9 @@ TransportFactory = Callable[[str, int, ssl.SSLContext | bool | None], Awaitable[
 # MQTT 5.0 §3.8.2.1.2: a subscription identifier is a variable-byte integer.
 _MAX_SUBSCRIPTION_IDENTIFIER = 268_435_455
 
+# MQTT 5.0 §3.3.2.3.4: a topic alias is a non-zero two-byte integer.
+_MAX_TOPIC_ALIAS = 65_535
+
 log = logging.getLogger(__name__)
 
 
@@ -599,6 +602,8 @@ class MQTTClient:
                 ``$`` in a non-leading position.
             MQTTDisconnectedError: If the client is not currently connected.
             RuntimeError: If *properties* is supplied on an MQTT 3.1.1 connection.
+            ValueError: If the topic alias is outside 1..65535 or exceeds the
+                server's Topic Alias Maximum for the current connection.
             MQTTPublishError: If the broker rejects a QoS 1/2 publish. Not raised for QoS 0 or MQTT 3.1.1.
         """
         validate_publish(topic)
@@ -608,6 +613,16 @@ class MQTTClient:
         if properties is not None and self._version != "5.0":
             msg = "properties require MQTT 5.0"
             raise RuntimeError(msg)
+        if properties is not None and properties.topic_alias is not None:
+            alias = properties.topic_alias
+            if not 1 <= alias <= _MAX_TOPIC_ALIAS:
+                msg = "topic_alias must be between 1 and 65535"
+                raise ValueError(msg)
+            connack_properties = self.connection_info.properties
+            maximum = 0 if connack_properties is None else (connack_properties.topic_alias_maximum or 0)
+            if alias > maximum:
+                msg = f"topic_alias {alias} exceeds server Topic Alias Maximum {maximum}"
+                raise ValueError(msg)
         if isinstance(payload, str):
             payload = payload.encode()
         await self._protocol.publish(
@@ -757,7 +772,8 @@ class MQTTClient:
             MQTTDisconnectedError: If the request cannot start because the client
                 is disconnected, or the client is stopped while waiting.
             ValueError: If the same response topic and correlation data are
-                already used by another active request.
+                already used by another active request. Also raised if the topic
+                alias is outside 1..65535 or exceeds the server's Topic Alias Maximum.
             asyncio.TimeoutError: If no matching reply arrives within *timeout*
                 seconds.
         """

--- a/tests/test_topic_alias.py
+++ b/tests/test_topic_alias.py
@@ -1,0 +1,166 @@
+"""Outgoing Topic Alias validation through the public client and real codec."""
+
+import asyncio
+import ssl
+
+import pytest
+
+from tests.test_connection_info import transport_factory
+from tests.test_protocol import FakeTransport
+from zmqtt import ConnAckProperties, MQTTClient, MQTTDisconnectedError, PublishProperties, QoS, ReconnectConfig
+from zmqtt._internal.packets.codec import encode
+from zmqtt._internal.packets.connect import ConnAck
+from zmqtt._internal.packets.publish import Publish
+from zmqtt._internal.packets.reader import PacketBuffer
+from zmqtt._internal.transport.base import Transport
+
+
+def feed_connack(transport: FakeTransport, properties: ConnAckProperties | None, *, resumed: bool = False) -> None:
+    transport.feed(encode(ConnAck(session_present=resumed, return_code=0, properties=properties), version="5.0"))
+
+
+@pytest.mark.parametrize("alias", [-1, 0, 65_536])
+@pytest.mark.parametrize("qos", list(QoS))
+async def test_rejects_alias_outside_protocol_range(alias: int, qos: QoS) -> None:
+    transport = FakeTransport()
+    feed_connack(transport, ConnAckProperties(topic_alias_maximum=65_535))
+    async with MQTTClient("localhost", version="5.0", transport_factory=transport_factory(transport)) as client:
+        sent = list(transport.sent)
+        with pytest.raises(ValueError, match="topic_alias must be between 1 and 65535"):
+            await asyncio.wait_for(
+                client.publish("test/topic", b"payload", qos=qos, properties=PublishProperties(topic_alias=alias)),
+                timeout=1,
+            )
+        assert transport.sent == sent
+        assert client._protocol is not None
+        assert not client._protocol._state.inflight_qos1
+        assert not client._protocol._state.inflight_qos2_out
+
+
+@pytest.mark.parametrize(
+    ("properties", "alias"),
+    [
+        (None, 1),
+        (ConnAckProperties(reason_string="welcome"), 1),
+        (ConnAckProperties(topic_alias_maximum=0), 1),
+        (ConnAckProperties(topic_alias_maximum=3), 4),
+    ],
+)
+@pytest.mark.parametrize("qos", list(QoS))
+async def test_rejects_alias_exceeding_server_limit(properties: ConnAckProperties | None, alias: int, qos: QoS) -> None:
+    transport = FakeTransport()
+    feed_connack(transport, properties)
+    async with MQTTClient("localhost", version="5.0", transport_factory=transport_factory(transport)) as client:
+        sent = list(transport.sent)
+        with pytest.raises(ValueError, match="exceeds server Topic Alias Maximum"):
+            await asyncio.wait_for(
+                client.publish("test/topic", b"payload", qos=qos, properties=PublishProperties(topic_alias=alias)),
+                timeout=1,
+            )
+        assert transport.sent == sent
+
+
+@pytest.mark.parametrize(("maximum", "alias"), [(1, 1), (3, 1), (3, 3), (65_535, 65_535)])
+async def test_accepts_alias_within_server_limit(maximum: int, alias: int) -> None:
+    transport = FakeTransport()
+    feed_connack(transport, ConnAckProperties(topic_alias_maximum=maximum))
+    properties = PublishProperties(topic_alias=alias)
+    async with MQTTClient("localhost", version="5.0", transport_factory=transport_factory(transport)) as client:
+        await client.publish("test/topic", "payload", properties=properties)
+        buffer = PacketBuffer(version="5.0")
+        buffer.feed(transport.sent[-1])
+        assert list(buffer) == [
+            Publish(
+                topic="test/topic",
+                payload=b"payload",
+                qos=QoS.AT_MOST_ONCE,
+                retain=False,
+                dup=False,
+                properties=properties,
+            )
+        ]
+
+
+@pytest.mark.parametrize("maximum", [None, 0, 3])
+@pytest.mark.parametrize("properties", [None, PublishProperties(content_type="text/plain")])
+async def test_publication_without_alias_is_independent_of_server_limit(
+    maximum: int | None, properties: PublishProperties | None
+) -> None:
+    transport = FakeTransport()
+    feed_connack(transport, ConnAckProperties(topic_alias_maximum=maximum))
+    async with MQTTClient("localhost", version="5.0", transport_factory=transport_factory(transport)) as client:
+        await client.publish("test/topic", b"payload", properties=properties)
+        buffer = PacketBuffer(version="5.0")
+        buffer.feed(transport.sent[-1])
+        assert list(buffer) == [
+            Publish(
+                topic="test/topic",
+                payload=b"payload",
+                qos=QoS.AT_MOST_ONCE,
+                retain=False,
+                dup=False,
+                properties=properties,
+            )
+        ]
+
+
+async def test_mqtt_v311_still_rejects_publish_properties() -> None:
+    transport = FakeTransport()
+    transport.feed(encode(ConnAck(session_present=False, return_code=0), version="3.1.1"))
+    async with MQTTClient("localhost", transport_factory=transport_factory(transport)) as client:
+        sent = list(transport.sent)
+        with pytest.raises(RuntimeError, match=r"properties require MQTT 5\.0"):
+            await client.publish("test/topic", b"payload", properties=PublishProperties(topic_alias=1))
+        assert transport.sent == sent
+        await client.publish("test/topic", b"without alias")
+
+
+@pytest.mark.parametrize("maximum", [None, 0, 1, 5])
+@pytest.mark.parametrize("resumed", [False, True])
+async def test_reconnect_uses_new_alias_limit(maximum: int | None, resumed: bool) -> None:
+    first, second = FakeTransport(), FakeTransport()
+    feed_connack(first, ConnAckProperties(topic_alias_maximum=3))
+    feed_connack(second, ConnAckProperties(topic_alias_maximum=maximum), resumed=resumed)
+    transports = iter([first, second])
+    reconnecting = asyncio.Event()
+    allow_reconnect = asyncio.Event()
+
+    async def factory(host: str, port: int, tls: ssl.SSLContext | bool | None) -> Transport:  # noqa: ARG001
+        transport = next(transports)
+        if transport is second:
+            reconnecting.set()
+            await allow_reconnect.wait()
+        return transport
+
+    client = MQTTClient(
+        "localhost",
+        version="5.0",
+        clean_session=False,
+        session_expiry_interval=60,
+        transport_factory=factory,
+        reconnect=ReconnectConfig(initial_delay=0),
+    )
+    async with client:
+        properties = PublishProperties(topic_alias=3)
+        await client.publish("test/topic", b"first", properties=properties)
+        first._rx.append(MQTTDisconnectedError("lost"))
+        await asyncio.wait_for(reconnecting.wait(), timeout=1)
+        sent = list(first.sent)
+        with pytest.raises(MQTTDisconnectedError):
+            await client.publish("test/topic", b"during reconnect", properties=properties)
+        assert first.sent == sent
+        allow_reconnect.set()
+
+        async def wait_for_reconnect() -> None:
+            while client._connection_info is None or client._connection_info.connection_id != 2:  # noqa: ASYNC110
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(wait_for_reconnect(), timeout=1)
+        if maximum is None or maximum < 3:
+            sent = list(second.sent)
+            with pytest.raises(ValueError, match="exceeds server Topic Alias Maximum"):
+                await client.publish("test/topic", b"second", properties=properties)
+            assert second.sent == sent
+        if maximum:
+            await client.publish("test/topic", b"second", properties=PublishProperties(topic_alias=maximum))
+        await client.publish("test/topic", b"without alias")


### PR DESCRIPTION
## Summary

  Implement outgoing Topic Alias validation according to [MQTT 5.0 §3.2.2.3.8 (Topic Alias Maximum) and §3.3.2.3.4 (Topic Alias)](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html).

  Before sending PUBLISH:

  - Reject values outside 1..65535 or above the server's Topic Alias Maximum.
  - Reject aliases when the server omits the maximum or sets it to zero.
  - Use the current connection's limit, including after reconnect.
  - Keep publications without a Topic Alias unaffected.

  Closes #78

  ## Validation

- Added tests for invalid aliases (-1, 0, 65536), missing/zero/exceeded server limits, valid boundary values, updated limits after reconnect, publications without aliases, and MQTT 3.1.1 compatibility (6 test functions, 40 cases).
- Full test suite on Python 3.11 with all five brokers: 732 passed, 24 skipped (existing protocol/broker-specific skips).
- Ruff lint and formatting, mypy, mkdocs build --strict, uv build, and Bandit passed.
- Final docstring and documentation edits passed git diff --check.

- [x] Tests were added or updated when behavior changed
- [x] Documentation was updated when the public API changed
- [x] The PR title follows Conventional Commits, for example `feat(client): add reconnect timeout`
