### PR TITLE
feat(client): honor the server's Maximum QoS

### DIFF
--- a/src/zmqtt/__init__.py
+++ b/src/zmqtt/__init__.py
@@ -26,6 +26,7 @@ from zmqtt.errors import (
     MQTTInvalidTopicError,
     MQTTProtocolError,
     MQTTPublishError,
+    MQTTQoSExceededError,
     MQTTSubscribeError,
     MQTTTimeoutError,
 )
@@ -44,6 +45,7 @@ __all__ = (
     "MQTTInvalidTopicError",
     "MQTTProtocolError",
     "MQTTPublishError",
+    "MQTTQoSExceededError",
     "MQTTSubscribeError",
     "MQTTTimeoutError",
     "Message",

--- a/src/zmqtt/_internal/protocol.py
+++ b/src/zmqtt/_internal/protocol.py
@@ -40,6 +40,7 @@ from zmqtt.errors import (
     MQTTDisconnectedError,
     MQTTProtocolError,
     MQTTPublishError,
+    MQTTQoSExceededError,
     MQTTSubscribeError,
     MQTTTimeoutError,
 )
@@ -171,6 +172,8 @@ class MQTTProtocol:
         self._subscription_guards = _SubscriptionGuards()
         self._disconnecting = False
         self._dead = False
+        # MQTT 5 §3.2.2.3.4: absent Maximum QoS means the server accepts QoS 2.
+        self._max_publish_qos: int | None = None
         self.started_event = asyncio.Event()
 
     async def connect(self, packet: Connect) -> ConnAck:
@@ -201,6 +204,9 @@ class MQTTProtocol:
                 if pkt.return_code != 0:
                     raise MQTTConnectError(pkt.return_code, properties=pkt.properties)
                 log.info("Connected with session_present=%s", pkt.session_present)
+                self._max_publish_qos = (
+                    pkt.properties.maximum_qos if (self._version == "5.0" and pkt.properties is not None) else None
+                )
                 self.inbound.begin_session(session_present=pkt.session_present)
                 return pkt
 
@@ -267,6 +273,9 @@ class MQTTProtocol:
         Publish a message. Returns PubAck (QoS 1), PubComp (QoS 2), or None (QoS 0).
         """
         self._ensure_alive()
+        max_qos = self._max_publish_qos
+        if max_qos is not None and packet.qos > max_qos:
+            raise MQTTQoSExceededError(requested=int(packet.qos), maximum=max_qos)
         match packet.qos:
             case QoS.AT_MOST_ONCE:
                 await self._send(self._encode(packet))

--- a/src/zmqtt/_internal/protocol.py
+++ b/src/zmqtt/_internal/protocol.py
@@ -172,8 +172,10 @@ class MQTTProtocol:
         self._subscription_guards = _SubscriptionGuards()
         self._disconnecting = False
         self._dead = False
-        # MQTT 5 §3.2.2.3.4: absent Maximum QoS means the server accepts QoS 2.
-        self._max_publish_qos: int | None = None
+        # MQTT 5 §3.2.2.3.4: absent Maximum QoS means the server accepts QoS 2,
+        # and 3.1.1 has no CONNACK properties at all — default to EXACTLY_ONCE
+        # so publish() never has to branch on None.
+        self._max_publish_qos: QoS = QoS.EXACTLY_ONCE
         self.started_event = asyncio.Event()
 
     async def connect(self, packet: Connect) -> ConnAck:
@@ -204,9 +206,12 @@ class MQTTProtocol:
                 if pkt.return_code != 0:
                     raise MQTTConnectError(pkt.return_code, properties=pkt.properties)
                 log.info("Connected with session_present=%s", pkt.session_present)
-                self._max_publish_qos = (
-                    pkt.properties.maximum_qos if (self._version == "5.0" and pkt.properties is not None) else None
-                )
+                if self._version == "5.0" and pkt.properties is not None:
+                    # Properties present but Maximum QoS absent: spec default is QoS 2.
+                    max_qos = pkt.properties.maximum_qos
+                    self._max_publish_qos = QoS.EXACTLY_ONCE if max_qos is None else QoS(max_qos)
+                else:  # 3.1.1 has no CONNACK properties: no limit.
+                    self._max_publish_qos = QoS.EXACTLY_ONCE
                 self.inbound.begin_session(session_present=pkt.session_present)
                 return pkt
 
@@ -274,8 +279,8 @@ class MQTTProtocol:
         """
         self._ensure_alive()
         max_qos = self._max_publish_qos
-        if max_qos is not None and packet.qos > max_qos:
-            raise MQTTQoSExceededError(requested=int(packet.qos), maximum=max_qos)
+        if packet.qos > max_qos:
+            raise MQTTQoSExceededError(requested=int(packet.qos), maximum=int(max_qos))
         match packet.qos:
             case QoS.AT_MOST_ONCE:
                 await self._send(self._encode(packet))

--- a/src/zmqtt/errors.py
+++ b/src/zmqtt/errors.py
@@ -21,6 +21,19 @@ class MQTTProtocolError(MQTTError):
     """Unexpected or malformed packet received."""
 
 
+class MQTTQoSExceededError(MQTTError):
+    """A PUBLISH requested a QoS higher than the server's advertised Maximum QoS.
+
+    Raised locally, before the packet is sent — the server would otherwise
+    have to reject or drop it (MQTT 5.0 §3.2.2.3.4).
+    """
+
+    def __init__(self, requested: int, maximum: int) -> None:
+        self.requested_qos = requested
+        self.maximum_qos = maximum
+        super().__init__(f"Requested QoS {requested} exceeds the server's Maximum QoS {maximum}")
+
+
 class MQTTDisconnectedError(MQTTError):
     """Connection lost unexpectedly."""
 

--- a/tests/test_maximum_qos.py
+++ b/tests/test_maximum_qos.py
@@ -129,7 +129,7 @@ async def test_v5_connack_with_properties_but_no_maximum_qos() -> None:
         )
     )
     await protocol.connect(Connect(client_id="c", clean_session=True, keepalive=60))
-    assert protocol._max_publish_qos is None
+    assert protocol._max_publish_qos is QoS.EXACTLY_ONCE
     transport.sent.clear()
 
     read_task = await _run_read_loop(protocol)
@@ -189,7 +189,7 @@ async def test_reconnect_refreshes_limit() -> None:
     # Fresh protocol object per connection mirrors _connect_with_retry, which
     # builds a new MQTTProtocol each attempt; verify the new limit applies.
     protocol1, _ = await _connected_protocol(maximum_qos=None)
-    assert protocol1._max_publish_qos is None
+    assert protocol1._max_publish_qos is QoS.EXACTLY_ONCE
 
     protocol2, transport2 = await _connected_protocol(maximum_qos=0)
     assert protocol2._max_publish_qos == 0

--- a/tests/test_maximum_qos.py
+++ b/tests/test_maximum_qos.py
@@ -1,0 +1,211 @@
+"""Tests for MQTT 5 Maximum QoS enforcement (server limit from CONNACK)."""
+
+import asyncio
+import contextlib
+
+import pytest
+
+from zmqtt import MQTTQoSExceededError
+from zmqtt._internal.packets.codec import encode
+from zmqtt._internal.packets.connect import ConnAck, Connect
+from zmqtt._internal.packets.properties import ConnAckProperties
+from zmqtt._internal.packets.publish import Publish
+from zmqtt._internal.protocol import MQTTProtocol
+from zmqtt._internal.types.qos import QoS
+from zmqtt.errors import MQTTPublishError
+
+from .test_protocol import FakeTransport, _run_read_loop, _stop_task, make_protocol
+
+
+def _feed_connack(transport: FakeTransport, *, maximum_qos: int | None) -> None:
+    properties = ConnAckProperties(maximum_qos=maximum_qos) if maximum_qos is not None else None
+    transport.feed(encode(ConnAck(session_present=False, return_code=0, properties=properties), version="5.0"))
+
+
+async def _connected_protocol(maximum_qos: int | None) -> tuple[MQTTProtocol, FakeTransport]:
+    protocol, transport = make_protocol(version="5.0")
+    _feed_connack(transport, maximum_qos=maximum_qos)
+    await protocol.connect(Connect(client_id="c", clean_session=True, keepalive=60))
+    transport.sent.clear()
+    return protocol, transport
+
+
+@pytest.mark.parametrize("qos", [QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
+async def test_publish_above_maximum_qos_raises_before_send(qos: QoS) -> None:
+    protocol, transport = await _connected_protocol(maximum_qos=0)
+
+    with pytest.raises(MQTTQoSExceededError) as exc_info:
+        await protocol.publish(
+            Publish(topic="t/x", payload=b"p", qos=qos, retain=False, dup=False, packet_id=0),
+        )
+
+    assert exc_info.value.requested_qos == int(qos)
+    assert exc_info.value.maximum_qos == 0
+    assert transport.sent == []  # nothing left the wire
+
+
+async def test_publish_qos2_above_maximum_qos_1_raises() -> None:
+    protocol, transport = await _connected_protocol(maximum_qos=1)
+
+    with pytest.raises(MQTTQoSExceededError):
+        await protocol.publish(
+            Publish(topic="t/x", payload=b"p", qos=QoS.EXACTLY_ONCE, retain=False, dup=False, packet_id=0),
+        )
+    assert transport.sent == []
+
+
+async def test_publish_at_or_below_maximum_qos_is_sent() -> None:
+    protocol, transport = await _connected_protocol(maximum_qos=1)
+
+    read_task = await _run_read_loop(protocol)
+    try:
+        task = asyncio.create_task(
+            protocol.publish(
+                Publish(
+                    topic="t/x",
+                    payload=b"p",
+                    qos=QoS.AT_LEAST_ONCE,
+                    retain=False,
+                    dup=False,
+                    packet_id=0,
+                ),
+            ),
+        )
+        await asyncio.sleep(0)
+        assert len(transport.sent) == 1  # the PUBLISH went out
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, MQTTPublishError):
+            await task
+    finally:
+        await _stop_task(read_task)
+
+
+async def test_absent_maximum_qos_defaults_to_qos2() -> None:
+    protocol, transport = await _connected_protocol(maximum_qos=None)
+
+    read_task = await _run_read_loop(protocol)
+    try:
+        task = asyncio.create_task(
+            protocol.publish(
+                Publish(
+                    topic="t/x",
+                    payload=b"p",
+                    qos=QoS.EXACTLY_ONCE,
+                    retain=False,
+                    dup=False,
+                    packet_id=0,
+                ),
+            ),
+        )
+        await asyncio.sleep(0)
+        assert len(transport.sent) == 1  # no local rejection: absent limit means QoS 2 ok
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, MQTTPublishError):
+            await task
+    finally:
+        await _stop_task(read_task)
+
+
+async def test_qos0_always_allowed_under_maximum_qos_0() -> None:
+    protocol, transport = await _connected_protocol(maximum_qos=0)
+
+    await protocol.publish(
+        Publish(topic="t/x", payload=b"p", qos=QoS.AT_MOST_ONCE, retain=False, dup=False, packet_id=0),
+    )
+    assert len(transport.sent) == 1
+
+
+async def test_v5_connack_with_properties_but_no_maximum_qos() -> None:
+    # Properties present, Maximum QoS absent: spec default is QoS 2 — no limit.
+    protocol, transport = make_protocol(version="5.0")
+    transport.feed(
+        encode(
+            ConnAck(
+                session_present=False,
+                return_code=0,
+                properties=ConnAckProperties(session_expiry_interval=60),
+            ),
+            version="5.0",
+        )
+    )
+    await protocol.connect(Connect(client_id="c", clean_session=True, keepalive=60))
+    assert protocol._max_publish_qos is None
+    transport.sent.clear()
+
+    read_task = await _run_read_loop(protocol)
+    try:
+        task = asyncio.create_task(
+            protocol.publish(
+                Publish(
+                    topic="t/x",
+                    payload=b"p",
+                    qos=QoS.EXACTLY_ONCE,
+                    retain=False,
+                    dup=False,
+                    packet_id=0,
+                ),
+            ),
+        )
+        await asyncio.sleep(0)
+        assert len(transport.sent) == 1
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, MQTTPublishError):
+            await task
+    finally:
+        await _stop_task(read_task)
+
+
+async def test_v311_connack_never_applies_limit() -> None:
+    # 3.1.1 has no CONNACK properties; QoS 2 must go through untouched.
+    protocol, transport = make_protocol(version="3.1.1")
+    transport.feed(encode(ConnAck(session_present=False, return_code=0), version="3.1.1"))
+    await protocol.connect(Connect(client_id="c", clean_session=True, keepalive=60))
+    transport.sent.clear()
+
+    read_task = await _run_read_loop(protocol)
+    try:
+        task = asyncio.create_task(
+            protocol.publish(
+                Publish(
+                    topic="t/x",
+                    payload=b"p",
+                    qos=QoS.EXACTLY_ONCE,
+                    retain=False,
+                    dup=False,
+                    packet_id=0,
+                ),
+            ),
+        )
+        await asyncio.sleep(0)
+        assert len(transport.sent) == 1
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, MQTTPublishError):
+            await task
+    finally:
+        await _stop_task(read_task)
+
+
+async def test_reconnect_refreshes_limit() -> None:
+    # Fresh protocol object per connection mirrors _connect_with_retry, which
+    # builds a new MQTTProtocol each attempt; verify the new limit applies.
+    protocol1, _ = await _connected_protocol(maximum_qos=None)
+    assert protocol1._max_publish_qos is None
+
+    protocol2, transport2 = await _connected_protocol(maximum_qos=0)
+    assert protocol2._max_publish_qos == 0
+    with pytest.raises(MQTTQoSExceededError):
+        await protocol2.publish(
+            Publish(topic="t/x", payload=b"p", qos=QoS.AT_LEAST_ONCE, retain=False, dup=False, packet_id=0),
+        )
+    assert transport2.sent == []
+
+
+async def test_subscribe_qos_is_not_limited() -> None:
+    # §3.2.2.3.4: Maximum QoS constrains PUBLISH only; a SUBSCRIBE may still
+    # request a higher QoS. Sanity-check the guard did not bleed into state.
+    protocol, _ = await _connected_protocol(maximum_qos=0)
+    assert protocol._max_publish_qos == 0
+    # subscribe() itself talks to the broker; the limit must not pre-reject it.
+    # (Full SUBSCRIBE flow is covered by broker E2E tests; here we only assert
+    # the protocol object stores no subscription-side cap.)
+    assert not hasattr(protocol, "_max_subscribe_qos")


### PR DESCRIPTION
Fixes #74.

zmqtt ignored the Maximum QoS property from CONNACK, so a caller could send QoS 1/2 PUBLISHes to a broker that advertises a lower maximum. Now:

- The limit is captured in `_await_connack` (v5 only; v3.1.1 has no CONNACK properties so it stays unlimited).
- `publish()` raises the new `MQTTQoSExceededError` (exported from `zmqtt`) before anything hits the wire — before the QoS branch, packet-id acquisition, and send. No silent downgrade.
- Absent property means QoS 2 per §3.2.2.3.4, including the case where CONNACK carries other properties but no Maximum QoS (tested).
- Reconnects pick up the fresh limit for free: each `_connect` builds a new `MQTTProtocol` with a new `SessionState`, so there is no in-flight retransmit path that could bypass the check.
- SUBSCRIBE is untouched: Requested QoS is a separate concept and stays unconstrained per spec.

Follow-up idea (out of scope here): Retain Available (#75) can reuse the same capture-point in `_await_connack`, ideally behind one `_check_server_limits(packet)` helper so publish-side checks don't grow as parallel ifs.

Tests: `pytest tests/ -q` (excluding the live-broker suite) — 238 passed including 10 new ones covering: rejection above max (QoS 1/2 over 0, QoS 2 over 1) with nothing sent, allowed publishes at/below the limit, absent property → QoS 2, properties-present-but-no-maximum_qos → QoS 2, v3.1.1 unlimited, reconnect refresh, and QoS 0 always allowed. `ruff` and `mypy` clean.