### PR TITLE
feat(client): stateful MQTT 5 Topic Alias support (#83)

### DIFF
--- a/src/zmqtt/__init__.py
+++ b/src/zmqtt/__init__.py
@@ -29,6 +29,7 @@ from zmqtt.errors import (
     MQTTQoSExceededError,
     MQTTSubscribeError,
     MQTTTimeoutError,
+    MQTTTopicAliasError,
 )
 
 __all__ = (
@@ -48,6 +49,7 @@ __all__ = (
     "MQTTQoSExceededError",
     "MQTTSubscribeError",
     "MQTTTimeoutError",
+    "MQTTTopicAliasError",
     "Message",
     "PublishProperties",
     "QoS",

--- a/src/zmqtt/_internal/protocol.py
+++ b/src/zmqtt/_internal/protocol.py
@@ -32,6 +32,13 @@ from zmqtt._internal.state import (
     SessionState,
 )
 from zmqtt._internal.subscription_index import SubscriptionEntry
+from zmqtt._internal.topic_aliases import (
+    OutgoingAliasLimitError,
+    TopicAliasError,
+    TopicAliasTable,
+    resolve_incoming,
+    validate_alias_range,
+)
 from zmqtt._internal.transport.base import Transport
 from zmqtt._internal.types.message import Message
 from zmqtt._internal.types.qos import QoS
@@ -43,6 +50,7 @@ from zmqtt.errors import (
     MQTTQoSExceededError,
     MQTTSubscribeError,
     MQTTTimeoutError,
+    MQTTTopicAliasError,
 )
 
 log = logging.getLogger("zmqtt.protocol")
@@ -152,8 +160,15 @@ class MQTTProtocol:
         request_router: RequestRouter | None = None,
         session_replay_buffer_size: int = 1000,
         session_replay_timeout: float = 30.0,
+        incoming_topic_alias_maximum: int = 0,
     ) -> None:
         self._transport = transport
+        if incoming_topic_alias_maximum < 0 or incoming_topic_alias_maximum > 65535:
+            msg = "incoming_topic_alias_maximum must be in 0..65535"
+            raise ValueError(msg)
+        # Advertised in CONNECT: how many aliases the *server* may use towards
+        # us. 0 (default) keeps incoming aliases disabled.
+        self._incoming_alias_maximum: Final = incoming_topic_alias_maximum
         self._state = state
         self._keepalive = keepalive
         self._ping_timeout = ping_timeout
@@ -176,6 +191,10 @@ class MQTTProtocol:
         # and 3.1.1 has no CONNACK properties at all — default to EXACTLY_ONCE
         # so publish() never has to branch on None.
         self._max_publish_qos: QoS = QoS.EXACTLY_ONCE
+        # Topic Alias state (§3.3.2.3.4), per network connection. Both tables
+        # are (re)initialized on every CONNACK — see _await_connack.
+        self._outgoing_aliases = TopicAliasTable(limit=0)
+        self._incoming_aliases = TopicAliasTable(limit=0)
         self.started_event = asyncio.Event()
 
     async def connect(self, packet: Connect) -> ConnAck:
@@ -212,6 +231,14 @@ class MQTTProtocol:
                     self._max_publish_qos = QoS.EXACTLY_ONCE if max_qos is None else QoS(max_qos)
                 else:  # 3.1.1 has no CONNACK properties: no limit.
                     self._max_publish_qos = QoS.EXACTLY_ONCE
+                # Fresh network connection: clear all Topic Alias state, resumed
+                # sessions included (§3.3.2.3.4 — aliases are connection-scoped),
+                # then adopt the server's Topic Alias Maximum as our outgoing cap.
+                server_alias_max = 0
+                if self._version == "5.0" and pkt.properties is not None:
+                    server_alias_max = pkt.properties.topic_alias_maximum or 0
+                self._outgoing_aliases = TopicAliasTable(limit=server_alias_max)
+                self._incoming_aliases = TopicAliasTable(limit=self._incoming_alias_maximum)
                 self.inbound.begin_session(session_present=pkt.session_present)
                 return pkt
 
@@ -273,6 +300,37 @@ class MQTTProtocol:
             msg = "Connection lost"
             raise MQTTDisconnectedError(msg)
 
+    def _apply_outgoing_topic_alias(self, packet: Publish) -> Publish:
+        """Enforce §3.3.2.3.4 on one outgoing PUBLISH.
+
+        v5 with properties.topic_alias set:
+        - non-empty topic: validate + (re)bind the alias, send as-is;
+        - empty topic: must reference an alias registered earlier on this
+          connection; the packet keeps the empty Topic Name so the wire
+          form carries only the alias (§3.3.2.3.4 payload saving).
+        """
+        if self._version != "5.0":
+            return packet
+        alias = packet.properties.topic_alias if packet.properties is not None else None
+        if alias is None:
+            return packet
+        try:
+            # Range first so alias=0/65536 report the actual problem, not
+            # a confusing "unregistered alias".
+            validate_alias_range(alias)
+            if packet.topic:
+                self._outgoing_aliases.set(alias, packet.topic)
+                return packet
+            resolved = self._outgoing_aliases.get(alias)
+            if resolved is not None:
+                return packet
+            msg = f"Empty Topic Name for unregistered Topic Alias {alias}"
+        except OutgoingAliasLimitError as exc:
+            raise MQTTTopicAliasError(str(exc)) from exc
+        except TopicAliasError as exc:
+            raise MQTTTopicAliasError(str(exc)) from exc
+        raise MQTTTopicAliasError(msg)
+
     async def publish(self, packet: Publish) -> PubAck | PubComp | None:
         """
         Publish a message. Returns PubAck (QoS 1), PubComp (QoS 2), or None (QoS 0).
@@ -281,6 +339,7 @@ class MQTTProtocol:
         max_qos = self._max_publish_qos
         if packet.qos > max_qos:
             raise MQTTQoSExceededError(requested=int(packet.qos), maximum=int(max_qos))
+        packet = self._apply_outgoing_topic_alias(packet)
         match packet.qos:
             case QoS.AT_MOST_ONCE:
                 await self._send(self._encode(packet))
@@ -569,7 +628,29 @@ class MQTTProtocol:
         return self.inbound.select_recipient(publish)
 
     async def _handle_publish(self, packet: Publish) -> None:
-        await self.inbound.handle_publish(packet)
+        await self.inbound.handle_publish(await self._resolve_incoming_topic_alias(packet))
+
+    async def _resolve_incoming_topic_alias(self, packet: Publish) -> Publish:
+        """Resolve §3.3.2.3.4 aliases on one inbound PUBLISH; maybe rewrite it.
+
+        Violations tear the connection down with DISCONNECT 0x82 (Protocol
+        Error) after §3.14.2.2.1 — the sender misused the alias mechanism.
+        """
+        if self._version != "5.0":
+            return packet
+        alias = packet.properties.topic_alias if packet.properties is not None else None
+        if alias is None:
+            return packet
+        try:
+            resolved = resolve_incoming(packet.topic, alias, self._incoming_aliases)
+        except TopicAliasError as exc:
+            # §3.14.2.2.1: DISCONNECT 0x82 Protocol Error, then close.
+            with contextlib.suppress(Exception):
+                await self._send(self._encode(Disconnect(reason_code=0x82)))
+            raise MQTTProtocolError(str(exc)) from exc
+        if resolved == packet.topic:
+            return packet
+        return dataclasses.replace(packet, topic=resolved)
 
     async def _handle_pubrel(self, packet: PubRel) -> None:
         await self.inbound.handle_pubrel(packet)

--- a/src/zmqtt/_internal/topic_aliases.py
+++ b/src/zmqtt/_internal/topic_aliases.py
@@ -1,0 +1,93 @@
+"""Connection-scoped Topic Alias state (MQTT 5.0 §3.3.2.3.4).
+
+Two independent mappings live per network connection:
+
+- Outgoing: the client registers alias→topic and may then publish with an
+  empty Topic Name, sending only the alias. The limit is the server's
+  Topic Alias Maximum from CONNACK (absent ⇒ 0 ⇒ aliases not allowed).
+- Incoming: the client advertises its own Topic Alias Maximum in CONNECT;
+  0 (the default) tells the server not to use aliases. Incoming PUBLISHes
+  carrying an alias are resolved to the full topic before routing.
+
+Both mappings are cleared on every new network connection, resumed
+sessions included — aliases are strictly connection-scoped state.
+"""
+
+from __future__ import annotations
+
+# Alias values travel as a two-byte integer; 0 is a protocol error (§3.3.2.3.4).
+MAX_ALIAS = 65535
+_MIN_ALIAS = 1
+
+
+class TopicAliasError(Exception):
+    """Base for local Topic Alias violations."""
+
+
+class OutgoingAliasLimitError(TopicAliasError):
+    """The server's Topic Alias Maximum does not allow this alias."""
+
+
+class UnknownIncomingAliasError(TopicAliasError):
+    """An alias-only PUBLISH referenced an alias this connection never set."""
+
+
+def validate_alias_range(alias: int) -> None:
+    """Alias 0 is a protocol error; values fit a two-byte integer."""
+    if not _MIN_ALIAS <= alias <= MAX_ALIAS:
+        msg = f"Topic Alias must be in {_MIN_ALIAS}..{MAX_ALIAS}, got {alias}"
+        raise TopicAliasError(msg)
+
+
+class TopicAliasTable:
+    """One direction of the connection-scoped alias mapping."""
+
+    def __init__(self, limit: int = 0) -> None:
+        self._limit = limit
+        self._aliases: dict[int, str] = {}
+
+    @property
+    def limit(self) -> int:
+        return self._limit
+
+    def clear(self) -> None:
+        self._aliases.clear()
+
+    def set(self, alias: int, topic: str) -> None:
+        """Register or re-bind *alias* to *topic* (full Topic Name)."""
+        validate_alias_range(alias)
+        if alias > self._limit:
+            msg = f"Topic Alias {alias} exceeds the peer's Topic Alias Maximum {self._limit}"
+            raise OutgoingAliasLimitError(msg)
+        self._aliases[alias] = topic
+
+    def get(self, alias: int) -> str | None:
+        """Resolve *alias* to its full topic, or None if never set."""
+        return self._aliases.get(alias)
+
+
+def resolve_incoming(topic: str, alias: int | None, table: TopicAliasTable) -> str:
+    """Apply §3.3.2.3.4 to one incoming PUBLISH; return the full topic.
+
+    - alias set + full topic: (re)bind and return the topic as-is.
+    - alias set + empty topic: resolve through the table; an unknown alias
+      is a protocol error (the sender must establish it first).
+    - alias absent: topic must be non-empty (regular publish).
+    """
+    if alias is None:
+        if not topic:
+            msg = "Empty Topic Name without a Topic Alias"
+            raise TopicAliasError(msg)
+        return topic
+    validate_alias_range(alias)
+    if alias > table.limit:
+        msg = f"Peer sent Topic Alias {alias} above our advertised Topic Alias Maximum {table.limit}"
+        raise TopicAliasError(msg)
+    if topic:
+        table.set(alias, topic)
+        return topic
+    resolved = table.get(alias)
+    if resolved is None:
+        msg = f"Alias-only PUBLISH for unknown Topic Alias {alias}"
+        raise UnknownIncomingAliasError(msg)
+    return resolved

--- a/src/zmqtt/_internal/types/topic.py
+++ b/src/zmqtt/_internal/types/topic.py
@@ -1,8 +1,21 @@
 from zmqtt.errors import MQTTInvalidTopicError
 
+# Alias values travel as a two-byte integer; 0 is a protocol error (§3.3.2.3.4).
+_MAX_ALIAS = 65535
 
-def validate_publish(topic: str) -> None:
+
+def validate_publish(topic: str, *, topic_alias: int | None = None) -> None:
+    """Validate an outgoing PUBLISH topic (MQTT 5 §3.3.2.3.4 aware).
+
+    An empty Topic Name is legal only when a Topic Alias accompanies it;
+    the alias value itself is validated against 1..65535.
+    """
     if not topic:
+        if topic_alias is not None:
+            if not 1 <= topic_alias <= _MAX_ALIAS:
+                msg = f"Topic Alias must be in 1..{_MAX_ALIAS}, got {topic_alias}"
+                raise MQTTInvalidTopicError(msg)
+            return
         msg = "Topic must not be empty"
         raise MQTTInvalidTopicError(msg)
     if "#" in topic or "+" in topic:

--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -24,6 +24,7 @@ from zmqtt._internal.packets.subscribe import SubscriptionRequest
 from zmqtt._internal.protocol import MQTTProtocol
 from zmqtt._internal.request_response import _RequestDispatcher
 from zmqtt._internal.state import SessionState
+from zmqtt._internal.topic_aliases import MAX_ALIAS as _MAX_ALIAS
 from zmqtt._internal.topic_matching import _DEFAULT_STRIPPED_PREFIXES
 from zmqtt._internal.transport.base import Transport
 from zmqtt._internal.transport.tcp import open_tcp
@@ -407,6 +408,7 @@ class MQTTClient:
         max_pending_requests: int = 1000,
         session_replay_buffer_size: int = 1000,
         session_replay_timeout: float = 30.0,
+        topic_alias_maximum: int = 0,
     ) -> None:
         """Create an MQTT client.
 
@@ -461,9 +463,18 @@ class MQTTClient:
             session_replay_timeout: Seconds a persistent-session message may
                 remain in the replay buffer. Remaining messages are dropped
                 without acknowledgement after the timeout. Defaults to ``30.0``.
+            topic_alias_maximum: MQTT 5.0 Topic Alias Maximum to advertise in
+                CONNECT — how many aliases the *server* may use when publishing
+                towards this client (incoming aliases are disabled when ``0``,
+                the default). Outgoing aliases are governed separately by the
+                server's own Topic Alias Maximum from CONNACK. Ignored for
+                MQTT 3.1.1. Must be in ``0..65535``.
         """
         if not mqtt_connect_timeout > 0:
             msg = "mqtt_connect_timeout must be positive"
+            raise ValueError(msg)
+        if not 0 <= topic_alias_maximum <= _MAX_ALIAS:
+            msg = f"topic_alias_maximum must be in 0..{_MAX_ALIAS}"
             raise ValueError(msg)
         if session_replay_buffer_size < 0:
             msg = "session_replay_buffer_size must be non-negative"
@@ -493,6 +504,7 @@ class MQTTClient:
         self._request_dispatcher = _RequestDispatcher(max_pending_requests)
         self._session_replay_buffer_size = session_replay_buffer_size
         self._session_replay_timeout = session_replay_timeout
+        self._topic_alias_maximum = topic_alias_maximum
         self._connection_info: ConnectionInfo | None = None
         self._connection_id = 0
         self._protocol: MQTTProtocol | None = None
@@ -601,7 +613,10 @@ class MQTTClient:
             RuntimeError: If *properties* is supplied on an MQTT 3.1.1 connection.
             MQTTPublishError: If the broker rejects a QoS 1/2 publish. Not raised for QoS 0 or MQTT 3.1.1.
         """
-        validate_publish(topic)
+        validate_publish(
+            topic,
+            topic_alias=properties.topic_alias if properties is not None else None,
+        )
         if self._protocol is None:
             msg = "Not connected"
             raise MQTTDisconnectedError(msg)
@@ -828,11 +843,13 @@ class MQTTClient:
             request_router=self._request_dispatcher,
             session_replay_buffer_size=self._session_replay_buffer_size,
             session_replay_timeout=self._session_replay_timeout,
+            incoming_topic_alias_maximum=self._topic_alias_maximum,
         )
         connect_props = None
         if self._version == "5.0":
             connect_props = ConnectProperties(
                 session_expiry_interval=self._session_expiry_interval,
+                topic_alias_maximum=self._topic_alias_maximum or None,
             )
         connect_packet = Connect(
             client_id=self._client_id,
@@ -952,6 +969,7 @@ def create_client(
     max_pending_requests: int = ...,
     session_replay_buffer_size: int = ...,
     session_replay_timeout: float = ...,
+    topic_alias_maximum: int = ...,
 ) -> MQTTClientV311: ...
 
 
@@ -975,6 +993,7 @@ def create_client(
     max_pending_requests: int = ...,
     session_replay_buffer_size: int = ...,
     session_replay_timeout: float = ...,
+    topic_alias_maximum: int = ...,
     version: Literal["3.1.1"],
 ) -> MQTTClientV311: ...
 
@@ -999,6 +1018,7 @@ def create_client(
     max_pending_requests: int = ...,
     session_replay_buffer_size: int = ...,
     session_replay_timeout: float = ...,
+    topic_alias_maximum: int = ...,
     version: Literal["5.0"],
 ) -> MQTTClientV5: ...
 
@@ -1022,6 +1042,7 @@ def create_client(
     max_pending_requests: int = 1000,
     session_replay_buffer_size: int = 1000,
     session_replay_timeout: float = 30.0,
+    topic_alias_maximum: int = 0,
     version: Literal["3.1.1", "5.0"] = "3.1.1",
 ) -> MQTTClientV311 | MQTTClientV5:
     """Create a version-typed MQTT client.
@@ -1048,4 +1069,5 @@ def create_client(
         max_pending_requests=max_pending_requests,
         session_replay_buffer_size=session_replay_buffer_size,
         session_replay_timeout=session_replay_timeout,
+        topic_alias_maximum=topic_alias_maximum,
     )

--- a/src/zmqtt/errors.py
+++ b/src/zmqtt/errors.py
@@ -55,6 +55,15 @@ class MQTTSubscribeError(MQTTError):
         super().__init__(f"Broker rejected subscription: {rendered}")
 
 
+class MQTTTopicAliasError(MQTTError):
+    """An outgoing PUBLISH misused Topic Alias (MQTT 5 §3.3.2.3.4).
+
+    Raised locally, before the packet is sent: alias 0 or out of the 1..65535
+    range, above the server's Topic Alias Maximum from CONNACK, or an empty
+    Topic Name referencing an alias never registered on this connection.
+    """
+
+
 class MQTTPublishError(MQTTError):
     """The broker rejected a QoS 1/2 publish.
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -103,6 +103,7 @@ def make_protocol(
     ping_timeout: float = 5.0,
     stripped_prefixes: tuple[str, ...] = _DEFAULT_STRIPPED_PREFIXES,
     version: Literal["3.1.1", "5.0"] = "3.1.1",
+    incoming_topic_alias_maximum: int = 0,
 ) -> tuple[MQTTProtocol, FakeTransport]:
     transport = FakeTransport()
     state = SessionState()
@@ -113,6 +114,7 @@ def make_protocol(
         ping_timeout=ping_timeout,
         stripped_prefixes=stripped_prefixes,
         version=version,
+        incoming_topic_alias_maximum=incoming_topic_alias_maximum,
     )
     return protocol, transport
 

--- a/tests/test_topic_alias.py
+++ b/tests/test_topic_alias.py
@@ -1,0 +1,310 @@
+"""Tests for MQTT 5 Topic Alias support (§3.3.2.3.4, issue #83)."""
+
+import asyncio
+import contextlib
+
+import pytest
+
+from zmqtt import MQTTTopicAliasError
+from zmqtt._internal.packets.codec import decode, encode
+from zmqtt._internal.packets.connect import ConnAck, Connect
+from zmqtt._internal.packets.disconnect import Disconnect
+from zmqtt._internal.packets.properties import (
+    ConnAckProperties,
+    ConnectProperties,
+    PublishProperties,
+)
+from zmqtt._internal.packets.publish import Publish
+from zmqtt._internal.protocol import MQTTProtocol
+from zmqtt._internal.topic_aliases import (
+    TopicAliasError,
+    TopicAliasTable,
+    resolve_incoming,
+)
+from zmqtt._internal.types.qos import QoS
+from zmqtt.client import MQTTClient
+from zmqtt.errors import MQTTProtocolError
+
+from .test_client import FakeTransport as ClientFakeTransport
+from .test_protocol import FakeTransport, _run_read_loop, _stop_task, make_protocol
+
+
+def _feed_connack(
+    transport: FakeTransport,
+    *,
+    topic_alias_maximum: int | None,
+    maximum_qos: int | None = None,
+) -> None:
+    props = None
+    if topic_alias_maximum is not None or maximum_qos is not None:
+        props = ConnAckProperties(topic_alias_maximum=topic_alias_maximum, maximum_qos=maximum_qos)
+    transport.feed(encode(ConnAck(session_present=False, return_code=0, properties=props), version="5.0"))
+
+
+async def _connected_protocol(
+    *, topic_alias_maximum: int | None = None, incoming_maximum: int = 0
+) -> tuple[MQTTProtocol, FakeTransport]:
+    protocol, transport = make_protocol(version="5.0", incoming_topic_alias_maximum=incoming_maximum)
+    _feed_connack(transport, topic_alias_maximum=topic_alias_maximum)
+    await protocol.connect(Connect(client_id="c", clean_session=True, keepalive=60))
+    transport.sent.clear()
+    return protocol, transport
+
+
+def _alias_publish(alias: int, topic: str = "", qos: QoS = QoS.AT_MOST_ONCE) -> Publish:
+    return Publish(
+        topic=topic,
+        payload=b"p",
+        qos=qos,
+        retain=False,
+        dup=False,
+        properties=PublishProperties(topic_alias=alias),
+    )
+
+
+# ---------------------------------------------------------------------------
+# TopicAliasTable unit semantics
+
+
+def test_table_set_get_roundtrip() -> None:
+    table = TopicAliasTable(limit=5)
+    table.set(3, "sensors/temp")
+    assert table.get(3) == "sensors/temp"
+    assert table.get(4) is None
+
+
+def test_table_rebind_updates_topic() -> None:
+    table = TopicAliasTable(limit=5)
+    table.set(3, "a/b")
+    table.set(3, "c/d")
+    assert table.get(3) == "c/d"
+
+
+def test_table_rejects_alias_above_limit() -> None:
+    table = TopicAliasTable(limit=2)
+    with pytest.raises(TopicAliasError):
+        table.set(3, "a/b")
+
+
+def test_table_rejects_alias_zero() -> None:
+    table = TopicAliasTable(limit=5)
+    with pytest.raises(TopicAliasError):
+        table.set(0, "a/b")
+
+
+def test_table_clear_forgets_bindings() -> None:
+    table = TopicAliasTable(limit=5)
+    table.set(1, "a")
+    table.clear()
+    assert table.get(1) is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_incoming semantics
+
+
+def test_resolve_incoming_registers_full_topic() -> None:
+    table = TopicAliasTable(limit=5)
+    assert resolve_incoming("sensors/temp", 2, table) == "sensors/temp"
+    assert table.get(2) == "sensors/temp"
+
+
+def test_resolve_incoming_resolves_alias_only() -> None:
+    table = TopicAliasTable(limit=5)
+    resolve_incoming("sensors/temp", 2, table)
+    assert resolve_incoming("", 2, table) == "sensors/temp"
+
+
+def test_resolve_incoming_unknown_alias_raises() -> None:
+    table = TopicAliasTable(limit=10)
+    with pytest.raises(TopicAliasError, match="unknown"):
+        resolve_incoming("", 7, table)
+
+
+def test_resolve_incoming_empty_topic_without_alias_raises() -> None:
+    with pytest.raises(TopicAliasError, match="without a Topic Alias"):
+        resolve_incoming("", None, TopicAliasTable(limit=5))
+
+
+def test_resolve_incoming_alias_above_limit_raises() -> None:
+    table = TopicAliasTable(limit=3)
+    with pytest.raises(TopicAliasError, match="above our advertised"):
+        resolve_incoming("t", 4, table)
+
+
+# ---------------------------------------------------------------------------
+# Protocol: CONNACK negotiation + reset on new connection
+
+
+async def test_connack_without_alias_maximum_disables_outgoing() -> None:
+    protocol, _transport = await _connected_protocol(topic_alias_maximum=None)
+    assert protocol._outgoing_aliases.limit == 0
+    with pytest.raises(MQTTTopicAliasError, match="Topic Alias Maximum"):
+        await protocol.publish(_alias_publish(1, "a/b"))
+
+
+async def test_connack_sets_outgoing_limit() -> None:
+    protocol, _ = await _connected_protocol(topic_alias_maximum=10)
+    assert protocol._outgoing_aliases.limit == 10
+    await protocol.publish(_alias_publish(10, "a/b"))
+    assert protocol._outgoing_aliases.get(10) == "a/b"
+
+
+async def test_outgoing_alias_above_server_limit_raises() -> None:
+    protocol, _ = await _connected_protocol(topic_alias_maximum=2)
+    with pytest.raises(MQTTTopicAliasError, match="exceeds"):
+        await protocol.publish(_alias_publish(3, "a/b"))
+
+
+async def test_outgoing_alias_zero_raises() -> None:
+    protocol, _ = await _connected_protocol(topic_alias_maximum=5)
+    with pytest.raises(MQTTTopicAliasError, match=r"1\.\.65535"):
+        await protocol.publish(_alias_publish(0, "a/b"))
+
+
+async def test_alias_only_publish_resolves_registered_alias() -> None:
+    protocol, transport = await _connected_protocol(topic_alias_maximum=5)
+    read_task = await _run_read_loop(protocol)
+    try:
+        # Register alias 2 with a full topic, then reuse it with an empty topic.
+        await protocol.publish(_alias_publish(2, "sensors/temp"))
+        transport.sent.clear()
+        task = asyncio.create_task(protocol.publish(_alias_publish(2, "")))
+        await asyncio.sleep(0)
+        assert len(transport.sent) == 1
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+    finally:
+        await _stop_task(read_task)
+
+
+async def test_alias_only_wire_form_keeps_topic_empty() -> None:
+    # §3.3.2.3.4 payload saving: the wire PUBLISH must carry the alias and an
+    # EMPTY Topic Name — the resolved topic must not leak back onto the wire.
+    protocol, transport = await _connected_protocol(topic_alias_maximum=5)
+    await protocol.publish(_alias_publish(2, "sensors/temp"))
+    transport.sent.clear()
+    await protocol.publish(_alias_publish(2, ""))
+    assert len(transport.sent) == 1
+    decoded = decode(transport.sent[0], version="5.0")
+    assert decoded is not None
+    wire, _consumed = decoded
+    assert isinstance(wire, Publish)
+    assert wire.topic == ""
+    assert wire.properties is not None
+    assert wire.properties.topic_alias == 2
+
+
+async def test_alias_only_publish_unknown_alias_raises() -> None:
+    protocol, _ = await _connected_protocol(topic_alias_maximum=5)
+    with pytest.raises(MQTTTopicAliasError, match="unregistered"):
+        await protocol.publish(_alias_publish(2, ""))
+
+
+# ---------------------------------------------------------------------------
+# Protocol: incoming resolution
+
+
+def _feed_incoming_publish(transport: FakeTransport, packet: Publish) -> None:
+    transport.feed(encode(packet, version="5.0"))
+
+
+async def test_incoming_alias_only_is_resolved_before_routing() -> None:
+    protocol, transport = await _connected_protocol(topic_alias_maximum=5, incoming_maximum=5)
+    # Establish alias 4 with a full topic from the peer.
+    _feed_incoming_publish(transport, _alias_publish(4, "sensors/temp"))
+    # Alias-only follow-up resolves to the full topic.
+    _feed_incoming_publish(transport, _alias_publish(4, ""))
+    read_task = await _run_read_loop(protocol)
+    try:
+        await asyncio.sleep(0.05)
+        # No protocol error; subscription routing would see sensors/temp.
+    finally:
+        await _stop_task(read_task)
+    assert protocol._incoming_aliases.get(4) == "sensors/temp"
+
+
+async def test_incoming_alias_above_advertised_maximum_is_protocol_error() -> None:
+    protocol, transport = await _connected_protocol(topic_alias_maximum=5, incoming_maximum=3)
+    read_task = await _run_read_loop(protocol)
+    _feed_incoming_publish(transport, _alias_publish(4, "t"))
+    with pytest.raises(MQTTProtocolError, match="above our advertised"):
+        await asyncio.wait_for(read_task, timeout=2)
+    # §3.14.2.2.1: we told the peer why — DISCONNECT 0x82 went out first.
+    assert transport.sent, "expected a DISCONNECT before the teardown"
+    decoded = decode(transport.sent[-1], version="5.0")
+    assert decoded is not None
+    wire, _consumed = decoded
+    assert isinstance(wire, Disconnect)
+    assert wire.reason_code == 0x82
+
+
+async def test_incoming_unknown_alias_only_is_protocol_error() -> None:
+    protocol, transport = await _connected_protocol(topic_alias_maximum=5, incoming_maximum=10)
+    read_task = await _run_read_loop(protocol)
+    _feed_incoming_publish(transport, _alias_publish(9, ""))
+    with pytest.raises(MQTTProtocolError, match="unknown Topic Alias"):
+        await asyncio.wait_for(read_task, timeout=2)
+
+
+async def test_new_connection_clears_alias_state() -> None:
+    # Two CONNACKs through ONE protocol object (the reconnect path builds a
+    # new MQTTProtocol each attempt, but _await_connack must still reset the
+    # tables defensively — resumed sessions included).
+    protocol, transport = make_protocol(version="5.0")
+    _feed_connack(transport, topic_alias_maximum=5)
+    await protocol.connect(Connect(client_id="c", clean_session=True, keepalive=60))
+    await protocol.publish(_alias_publish(2, "sensors/temp"))
+    assert protocol._outgoing_aliases.get(2) == "sensors/temp"
+
+    # Second handshake on the same object: broker grants a different limit.
+    _feed_connack(transport, topic_alias_maximum=3)
+    await protocol.connect(Connect(client_id="c", clean_session=True, keepalive=60))
+    assert protocol._outgoing_aliases.get(2) is None
+    assert protocol._outgoing_aliases.limit == 3
+    assert protocol._incoming_aliases.get(2) is None
+
+
+async def test_incoming_disabled_by_default_zero_limit() -> None:
+    # incoming_maximum defaults to 0: any alias from the server is a violation.
+    protocol, transport = await _connected_protocol(topic_alias_maximum=5)
+    read_task = await _run_read_loop(protocol)
+    _feed_incoming_publish(transport, _alias_publish(1, "t"))
+    with pytest.raises(MQTTProtocolError, match="above our advertised"):
+        await asyncio.wait_for(read_task, timeout=2)
+
+
+# ---------------------------------------------------------------------------
+# Client plumbing
+
+
+async def test_client_advertises_topic_alias_maximum_in_connect() -> None:
+    captured_packet: dict[str, ConnectProperties | None] = {}
+
+    original_connect = MQTTProtocol.connect
+
+    async def _capture_connect(self: MQTTProtocol, packet: Connect) -> ConnAck:
+        captured_packet["props"] = packet.properties
+        return await original_connect(self, packet)
+
+    MQTTProtocol.connect = _capture_connect  # type: ignore[method-assign]
+    try:
+
+        async def factory(host: str, port: int, tls: object) -> ClientFakeTransport:  # noqa: ARG001
+            return ClientFakeTransport(
+                feed=encode(
+                    ConnAck(session_present=False, return_code=0, properties=ConnAckProperties()),
+                    version="5.0",
+                )
+            )
+
+        client = MQTTClient(
+            "h", transport_factory=factory, version="5.0", topic_alias_maximum=7, mqtt_connect_timeout=1.0
+        )
+        await client._connect()
+    finally:
+        MQTTProtocol.connect = original_connect  # type: ignore[method-assign]
+    props = captured_packet["props"]
+    assert props is not None
+    assert props.topic_alias_maximum == 7


### PR DESCRIPTION
Closes #83 (and the outgoing-validation half of #78).

## Summary

Implements connection-scoped Topic Alias state per MQTT 5 §3.3.2.3.4:

- **Outgoing aliases**: publish with a full Topic Name to register `properties.topic_alias`, then publish with an *empty* Topic Name — the wire PUBLISH keeps the topic empty and carries only the alias (the payload saving the mechanism exists for). Aliases are validated against 1..65535 and the server's **Topic Alias Maximum** from CONNACK before sending; an absent/zero maximum disables outgoing aliases entirely (`MQTTTopicAliasError`, raised locally pre-send).
- **Incoming aliases (opt-in)**: the new `topic_alias_maximum` kwarg on `MQTTClient`/`create_client` (default `0` = disabled) is advertised in CONNECT. Inbound aliases are resolved to the full Topic Name **before routing**; alias-only publishes for an unknown alias, or aliases above our advertised maximum, send DISCONNECT `0x82` (Protocol Error, §3.14.2.2.1) and tear the connection down via `MQTTProtocolError`.
- **Connection scoping**: both mapping tables are re-created on every CONNACK — resumed sessions included — so stale aliases can never leak across network connections. (The QoS 1/2 retransmission concern does not apply: zmqtt fails inflight publishes with `MQTTDisconnectedError` and builds a fresh protocol + session state per connection; there is no retransmit path.)
- `validate_publish()` now accepts an empty Topic Name when a valid Topic Alias accompanies it.
- New public error `MQTTTopicAliasError`, exported from `zmqtt`.

## Notes for reviewers

- The outgoing limit is negotiated per connection from CONNACK and refreshed on every reconnect.
- Regular publishes without an alias are untouched; MQTT 3.1.1 bypasses all alias logic.

## Test plan

- [x] `tests/test_topic_alias.py` — 23 cases: table semantics (bind/rebind/limit/clear), CONNACK renegotiation + reset on the *same* protocol object, outgoing register/reuse/reject paths, wire-form assertion that alias-only publishes keep the Topic Name empty, incoming resolve/registration/reject (with DISCONNECT 0x82 asserted on the wire), limits, client CONNECT advertisement capture.
- [x] Full unit suite: 261 passed (`pytest tests/ --ignore=tests/test_brokers`; broker E2E needs docker, not touched by this change).
- [x] `ruff check` + `ruff format --check` clean.
- [x] `mypy --strict` clean (56 files).