### PR TITLE
feat(client): report rejected UNSUBACK from Subscription.stop()

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,13 +32,6 @@ jobs:
         options: >-
           --security-opt no-new-privileges:true
 
-      mosquitto:
-        image: eclipse-mosquitto:2@sha256:6f8d8a947c506f8a2290ec65cd4bd2bc7cb4d43fb5f6271f861cb013e2ef9797  # 2.1.2-alpine
-        ports:
-          - 1884:1883
-        options: >-
-          --security-opt no-new-privileges:true
-
       hivemq:
         image: hivemq/hivemq-ce@sha256:7ae39e84654a41ced6e946dd84f131d508bc2b862ec96265b7f23d241db214da  # latest
         ports:
@@ -65,19 +58,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Copy mosquitto config
-        env:
-          MOSQUITTO_ID: ${{ job.services.mosquitto.id }}
-        run: |
-          echo "Mosquitto container: $MOSQUITTO_ID"
-          docker cp docker/mosquitto.conf "$MOSQUITTO_ID:/mosquitto/config/mosquitto.conf"
-          docker cp docker/mosquitto.acl "$MOSQUITTO_ID:/mosquitto/config/mosquitto.acl"
-          docker exec "$MOSQUITTO_ID" chmod 644 \
-            /mosquitto/config/mosquitto.conf \
-            /mosquitto/config/mosquitto.acl
-          # SIGHUP reloads the config and the ACL file without dropping the
-          # listener, so the service container keeps its published port.
-          docker kill -s HUP "$MOSQUITTO_ID"
+      # Mosquitto needs Dynamic Security to deny UNSUBSCRIBE, and its ACLs can only
+      # be provisioned once the broker runs, so it starts from compose instead.
+      - name: Start Mosquitto test service
+        run: docker compose up --detach --wait mosquitto
 
       - name: Wait for brokers
         run: |
@@ -123,10 +107,26 @@ jobs:
       - name: Install and start mosquitto
         run: |
           brew install mosquitto
-          printf 'listener 1884\nallow_anonymous true\nacl_file %s\n' \
-            "$GITHUB_WORKSPACE/docker/mosquitto.acl" > /tmp/mosquitto.conf
-          $(brew --prefix)/sbin/mosquitto -c /tmp/mosquitto.conf -d
+          MQTT_PREFIX="$(brew --prefix)"
+          SECURITY_FILE=/tmp/dynamic-security.json
+          "$MQTT_PREFIX/bin/mosquitto_ctrl" dynsec init "$SECURITY_FILE" admin admin
+          printf 'listener 1884\nallow_anonymous true\nplugin %s\nplugin_opt_config_file %s\n' \
+            "$MQTT_PREFIX/lib/mosquitto_dynamic_security.so" "$SECURITY_FILE" > /tmp/mosquitto.conf
+          "$MQTT_PREFIX/sbin/mosquitto" -c /tmp/mosquitto.conf -d
           sleep 2
+          dynsec() {
+            "$MQTT_PREFIX/bin/mosquitto_ctrl" -h 127.0.0.1 -p 1884 -u admin -P admin dynsec "$@"
+          }
+          dynsec setDefaultACLAccess publishClientSend allow
+          dynsec setDefaultACLAccess subscribe allow
+          dynsec createClient zmqtt-mosquitto -p zmqtt-mosquitto
+          dynsec createRole zmqtt-tests
+          dynsec addClientRole zmqtt-mosquitto zmqtt-tests 10
+          dynsec addRoleACL zmqtt-tests subscribePattern '#' allow 10
+          dynsec addRoleACL zmqtt-tests publishClientSend '#' allow 10
+          dynsec addRoleACL zmqtt-tests publishClientSend zmqtt/e2e/denied deny 20
+          dynsec addRoleACL zmqtt-tests unsubscribePattern '#' allow 10
+          dynsec addRoleACL zmqtt-tests unsubscribePattern 'zmqtt/unsuback/denied/#' deny 20
 
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
@@ -147,20 +147,73 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install and start mosquitto
+      - name: Install Mosquitto
         shell: pwsh
         run: |
           winget install -e --id EclipseFoundation.Mosquitto --accept-source-agreements --accept-package-agreements --silent
-          $acl = "$env:GITHUB_WORKSPACE\docker\mosquitto.acl"
-          Set-Content -Path "$env:TEMP\mosquitto.conf" -Value "listener 1884`r`nallow_anonymous true`r`nacl_file $acl"
-          Start-Process -FilePath "C:\Program Files\mosquitto\mosquitto.exe" -ArgumentList "-c $env:TEMP\mosquitto.conf" -WindowStyle Hidden
-          Start-Sleep -Seconds 3
+          $mosquittoDir = "C:\Program Files\mosquitto"
+          $ctrl = "$mosquittoDir/mosquitto_ctrl.exe"
+          $security = Join-Path $env:TEMP "dynamic-security.json"
+          & $ctrl dynsec init $security admin admin
+          $config = @(
+            "per_listener_settings false"
+            "plugin $mosquittoDir\mosquitto_dynamic_security.dll"
+            "plugin_opt_config_file $security"
+            "listener 1884"
+            "allow_anonymous true"
+          )
+          Set-Content -Path "$env:TEMP/mosquitto.conf" -Value $config -Encoding utf8NoBOM
+          "MOSQUITTO_DIR=$mosquittoDir" >> $env:GITHUB_ENV
+          "MOSQUITTO_CTRL=$ctrl" >> $env:GITHUB_ENV
+          "MOSQUITTO_CONFIG=$env:TEMP/mosquitto.conf" >> $env:GITHUB_ENV
 
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --locked --group dev
-      - run: uv run pytest -vv --ignore=tests/test_brokers/test_artemis.py --ignore=tests/test_brokers/test_hivemq.py --ignore=tests/test_brokers/test_nanomq.py --ignore=tests/test_brokers/test_emqx.py
+      # The broker must stay in the same step as pytest: a process started with
+      # Start-Process does not outlive the step on Windows runners.
+      - name: Run Mosquitto and targeted tests
+        shell: pwsh
+        run: |
+          $broker = Start-Process -FilePath "$env:MOSQUITTO_DIR/mosquitto.exe" `
+            -ArgumentList "-c $env:MOSQUITTO_CONFIG" `
+            -WorkingDirectory $env:MOSQUITTO_DIR `
+            -WindowStyle Hidden -PassThru
+          $testExitCode = 1
+          try {
+            Start-Sleep -Seconds 3
+            if ($broker.HasExited) {
+              throw "Mosquitto exited with code $($broker.ExitCode)"
+            }
+            function DynSec { & $env:MOSQUITTO_CTRL -h 127.0.0.1 -p 1884 -u admin -P admin dynsec @args }
+            DynSec setDefaultACLAccess publishClientSend allow
+            DynSec setDefaultACLAccess subscribe allow
+            DynSec createGroup zmqtt-anonymous-clients
+            DynSec createRole zmqtt-anonymous-role
+            DynSec addGroupRole zmqtt-anonymous-clients zmqtt-anonymous-role 10
+            DynSec addRoleACL zmqtt-anonymous-role subscribePattern '#' allow 10
+            DynSec addRoleACL zmqtt-anonymous-role publishClientSend '#' allow 10
+            DynSec setAnonymousGroup zmqtt-anonymous-clients
+            DynSec createClient zmqtt-mosquitto -p zmqtt-mosquitto
+            DynSec createRole zmqtt-tests
+            DynSec addClientRole zmqtt-mosquitto zmqtt-tests 10
+            DynSec addRoleACL zmqtt-tests subscribePattern '#' allow 10
+            DynSec addRoleACL zmqtt-tests publishClientSend '#' allow 10
+            DynSec addRoleACL zmqtt-tests publishClientSend zmqtt/e2e/denied deny 20
+            DynSec addRoleACL zmqtt-tests unsubscribePattern '#' allow 10
+            DynSec addRoleACL zmqtt-tests unsubscribePattern zmqtt/unsuback/denied/# deny 20
+            & uv run pytest -vv --ignore=tests/test_brokers/test_artemis.py --ignore=tests/test_brokers/test_hivemq.py --ignore=tests/test_brokers/test_nanomq.py --ignore=tests/test_brokers/test_emqx.py
+            $testExitCode = $LASTEXITCODE
+          } finally {
+            $broker.Refresh()
+            if (-not $broker.HasExited) {
+              Stop-Process -Id $broker.Id -Force
+            }
+          }
+          if ($testExitCode -ne 0) {
+            exit $testExitCode
+          }
 
   coverage:
     name: Publish coverage

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -111,20 +111,8 @@ jobs:
           printf 'listener 1884\nallow_anonymous true\nplugin %s\nplugin_opt_config_file %s\n' \
             "$MQTT_PREFIX/lib/mosquitto_dynamic_security.so" "$SECURITY_FILE" > /tmp/mosquitto.conf
           "$MQTT_PREFIX/sbin/mosquitto" -c /tmp/mosquitto.conf -d
-          sleep 2
-          dynsec() {
-            "$MQTT_PREFIX/bin/mosquitto_ctrl" -h 127.0.0.1 -p 1884 -u admin -P admin dynsec "$@"
-          }
-          dynsec setDefaultACLAccess publishClientSend allow
-          dynsec setDefaultACLAccess subscribe allow
-          dynsec createClient zmqtt-mosquitto -p zmqtt-mosquitto
-          dynsec createRole zmqtt-tests
-          dynsec addClientRole zmqtt-mosquitto zmqtt-tests 10
-          dynsec addRoleACL zmqtt-tests subscribePattern '#' allow 10
-          dynsec addRoleACL zmqtt-tests publishClientSend '#' allow 10
-          dynsec addRoleACL zmqtt-tests publishClientSend zmqtt/e2e/denied deny 20
-          dynsec addRoleACL zmqtt-tests unsubscribePattern '#' allow 10
-          dynsec addRoleACL zmqtt-tests unsubscribePattern 'zmqtt/unsuback/denied/#' deny 20
+          MOSQUITTO_CTRL="$MQTT_PREFIX/bin/mosquitto_ctrl" MOSQUITTO_PORT=1884 \
+            sh docker/dynsec-bootstrap.sh
 
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
@@ -180,27 +168,16 @@ jobs:
             -WindowStyle Hidden -PassThru
           $testExitCode = 1
           try {
-            Start-Sleep -Seconds 3
-            if ($broker.HasExited) {
-              throw "Mosquitto exited with code $($broker.ExitCode)"
+            $env:MOSQUITTO_CTRL = $env:MOSQUITTO_CTRL -replace '\\', '/'
+            $env:MOSQUITTO_PORT = "1884"
+            & bash docker/dynsec-bootstrap.sh
+            if ($LASTEXITCODE -ne 0) {
+              $broker.Refresh()
+              if ($broker.HasExited) {
+                throw "Mosquitto exited with code $($broker.ExitCode)"
+              }
+              throw "Dynamic Security bootstrap failed"
             }
-            function DynSec { & $env:MOSQUITTO_CTRL -h 127.0.0.1 -p 1884 -u admin -P admin dynsec @args }
-            DynSec setDefaultACLAccess publishClientSend allow
-            DynSec setDefaultACLAccess subscribe allow
-            DynSec createGroup zmqtt-anonymous-clients
-            DynSec createRole zmqtt-anonymous-role
-            DynSec addGroupRole zmqtt-anonymous-clients zmqtt-anonymous-role 10
-            DynSec addRoleACL zmqtt-anonymous-role subscribePattern '#' allow 10
-            DynSec addRoleACL zmqtt-anonymous-role publishClientSend '#' allow 10
-            DynSec setAnonymousGroup zmqtt-anonymous-clients
-            DynSec createClient zmqtt-mosquitto -p zmqtt-mosquitto
-            DynSec createRole zmqtt-tests
-            DynSec addClientRole zmqtt-mosquitto zmqtt-tests 10
-            DynSec addRoleACL zmqtt-tests subscribePattern '#' allow 10
-            DynSec addRoleACL zmqtt-tests publishClientSend '#' allow 10
-            DynSec addRoleACL zmqtt-tests publishClientSend zmqtt/e2e/denied deny 20
-            DynSec addRoleACL zmqtt-tests unsubscribePattern '#' allow 10
-            DynSec addRoleACL zmqtt-tests unsubscribePattern zmqtt/unsuback/denied/# deny 20
             & uv run pytest -vv --ignore=tests/test_brokers/test_artemis.py --ignore=tests/test_brokers/test_hivemq.py --ignore=tests/test_brokers/test_nanomq.py --ignore=tests/test_brokers/test_emqx.py
             $testExitCode = $LASTEXITCODE
           } finally {

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,8 +58,6 @@ jobs:
         with:
           persist-credentials: false
 
-      # Mosquitto needs Dynamic Security to deny UNSUBSCRIBE, and its ACLs can only
-      # be provisioned once the broker runs, so it starts from compose instead.
       - name: Start Mosquitto test service
         run: docker compose up --detach --wait mosquitto
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - no-new-privileges:true
 
   mosquitto:
-    image: eclipse-mosquitto:2
+    image: eclipse-mosquitto:2@sha256:6f8d8a947c506f8a2290ec65cd4bd2bc7cb4d43fb5f6271f861cb013e2ef9797 # 2.1.2-alpine
     command: /bin/sh /mosquitto/config/start-mosquitto-dynsec.sh
     volumes:
       - ./docker/mosquitto-dynsec.conf:/mosquitto/config/mosquitto-dynsec.conf:ro

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,11 +10,23 @@ services:
 
   mosquitto:
     image: eclipse-mosquitto:2
+    command: /bin/sh /mosquitto/config/start-mosquitto-dynsec.sh
     volumes:
-      - ./docker/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
-      - ./docker/mosquitto.acl:/mosquitto/config/mosquitto.acl:ro
+      - ./docker/mosquitto-dynsec.conf:/mosquitto/config/mosquitto-dynsec.conf:ro
+      - ./docker/start-mosquitto-dynsec.sh:/mosquitto/config/start-mosquitto-dynsec.sh:ro
+    tmpfs:
+      - /mosquitto/data
     ports:
       - "1884:1883"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "mosquitto_ctrl -h 127.0.0.1 -p 1883 -u admin -P admin dynsec getClient zmqtt-mosquitto >/dev/null 2>&1",
+        ]
+      interval: 1s
+      timeout: 2s
+      retries: 30
     security_opt:
       - no-new-privileges:true
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,7 @@ services:
     volumes:
       - ./docker/mosquitto-dynsec.conf:/mosquitto/config/mosquitto-dynsec.conf:ro
       - ./docker/start-mosquitto-dynsec.sh:/mosquitto/config/start-mosquitto-dynsec.sh:ro
+      - ./docker/dynsec-bootstrap.sh:/mosquitto/config/dynsec-bootstrap.sh:ro
     tmpfs:
       - /mosquitto/data
     ports:
@@ -22,7 +23,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "mosquitto_ctrl -h 127.0.0.1 -p 1883 -u admin -P admin dynsec getClient zmqtt-mosquitto >/dev/null 2>&1",
+          "mosquitto_ctrl -h 127.0.0.1 -p 1883 -u admin -P admin dynsec getClient zmqtt-mosquitto 2>&1 | grep -q zmqtt-tests",
         ]
       interval: 1s
       timeout: 2s

--- a/docker/dynsec-bootstrap.sh
+++ b/docker/dynsec-bootstrap.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+# Grant the Dynamic Security ACLs the broker tests rely on, on every platform
+# that runs them: the Mosquitto container, the macOS runner and the Windows one.
+#
+# MOSQUITTO_CTRL  path to mosquitto_ctrl (default: whatever is on PATH)
+# MOSQUITTO_PORT  port the broker listens on (default: 1883)
+set -eu
+
+ctrl=${MOSQUITTO_CTRL:-mosquitto_ctrl}
+port=${MOSQUITTO_PORT:-1883}
+
+dynsec() {
+    "$ctrl" -h 127.0.0.1 -p "$port" -u admin -P admin dynsec "$@" 2>&1
+}
+
+grant() {
+    dynsec setDefaultACLAccess publishClientSend allow
+    dynsec setDefaultACLAccess subscribe allow
+    dynsec createGroup zmqtt-anonymous-clients
+    dynsec createRole zmqtt-anonymous-role
+    dynsec addGroupRole zmqtt-anonymous-clients zmqtt-anonymous-role 10
+    dynsec addRoleACL zmqtt-anonymous-role subscribePattern '#' allow 10
+    dynsec addRoleACL zmqtt-anonymous-role publishClientSend '#' allow 10
+    dynsec setAnonymousGroup zmqtt-anonymous-clients
+    dynsec createClient zmqtt-mosquitto -p zmqtt-mosquitto
+    dynsec createRole zmqtt-tests
+    dynsec addClientRole zmqtt-mosquitto zmqtt-tests 10
+    dynsec addRoleACL zmqtt-tests subscribePattern '#' allow 10
+    dynsec addRoleACL zmqtt-tests publishClientSend '#' allow 10
+    dynsec addRoleACL zmqtt-tests publishClientSend 'zmqtt/e2e/denied' deny 20
+    dynsec addRoleACL zmqtt-tests unsubscribePattern '#' allow 10
+    dynsec addRoleACL zmqtt-tests unsubscribePattern 'zmqtt/unsuback/denied/#' deny 20
+}
+
+has_acls() {
+    acls=$(dynsec getRole "$1" | tr -s ' ')
+    shift
+    for acl in "$@"; do
+        printf '%s\n' "$acls" | grep -qF "$acl" || return 1
+    done
+}
+
+granted() {
+    dynsec getAnonymousGroup | grep -q zmqtt-anonymous-clients || return 1
+    dynsec getGroup zmqtt-anonymous-clients | grep -q zmqtt-anonymous-role || return 1
+    dynsec getClient zmqtt-mosquitto | grep -q zmqtt-tests || return 1
+    has_acls zmqtt-anonymous-role \
+        'subscribePattern : allow : #' \
+        'publishClientSend : allow : #' || return 1
+    has_acls zmqtt-tests \
+        'subscribePattern : allow : #' \
+        'publishClientSend : allow : #' \
+        'publishClientSend : deny : zmqtt/e2e/denied' \
+        'unsubscribePattern : allow : #' \
+        'unsubscribePattern : deny : zmqtt/unsuback/denied/#' || return 1
+}
+
+attempt=0
+until dynsec getClient admin | grep -q '^Username:'; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 30 ]; then
+        echo "Mosquitto Dynamic Security did not become ready" >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+# mosquitto_ctrl exits 0 even when the broker rejects a command, and a dropped
+# response is silent, so applying the grants once proves nothing. Every command
+# above is idempotent, so re-apply them until a read-back confirms all of them.
+attempt=0
+until grant >/dev/null && granted; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 3 ]; then
+        echo "Dynamic Security grants were not applied:" >&2
+        dynsec getClient zmqtt-mosquitto >&2
+        dynsec getRole zmqtt-tests >&2
+        exit 1
+    fi
+    sleep 1
+done

--- a/docker/mosquitto-dynsec.conf
+++ b/docker/mosquitto-dynsec.conf
@@ -1,0 +1,4 @@
+listener 1883
+allow_anonymous true
+plugin /usr/lib/mosquitto_dynamic_security.so
+plugin_opt_config_file /mosquitto/data/dynamic-security.json

--- a/docker/mosquitto.acl
+++ b/docker/mosquitto.acl
@@ -1,6 +1,0 @@
-# ACL for the test broker. Setting acl_file in mosquitto.conf switches mosquitto to
-# deny-by-default, so the file allows every topic and then denies only the one topic
-# the publish-rejection test needs.
-topic readwrite #
-topic readwrite $SYS/#
-topic deny zmqtt/e2e/denied

--- a/docker/mosquitto.conf
+++ b/docker/mosquitto.conf
@@ -1,3 +1,0 @@
-listener 1883
-allow_anonymous true
-acl_file /mosquitto/config/mosquitto.acl

--- a/docker/start-mosquitto-dynsec.sh
+++ b/docker/start-mosquitto-dynsec.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+data_dir=/mosquitto/data
+config_file=$data_dir/dynamic-security.json
+
+mkdir -p "$data_dir"
+chown mosquitto:mosquitto "$data_dir"
+mosquitto_ctrl dynsec init "$config_file" admin admin
+chown mosquitto:mosquitto "$config_file"
+chmod 640 "$config_file"
+
+mosquitto -c /mosquitto/config/mosquitto-dynsec.conf &
+broker_pid=$!
+
+attempt=0
+until mosquitto_ctrl -h 127.0.0.1 -p 1883 -u admin -P admin dynsec getClient admin >/dev/null 2>&1; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 30 ]; then
+        echo "Mosquitto Dynamic Security did not become ready" >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+dynsec() {
+    mosquitto_ctrl -h 127.0.0.1 -p 1883 -u admin -P admin dynsec "$@"
+}
+
+dynsec setDefaultACLAccess publishClientSend allow
+dynsec setDefaultACLAccess subscribe allow
+dynsec createClient zmqtt-mosquitto -p zmqtt-mosquitto
+dynsec createRole zmqtt-tests
+dynsec addClientRole zmqtt-mosquitto zmqtt-tests 10
+dynsec addRoleACL zmqtt-tests subscribePattern '#' allow 10
+dynsec addRoleACL zmqtt-tests publishClientSend '#' allow 10
+dynsec addRoleACL zmqtt-tests publishClientSend 'zmqtt/e2e/denied' deny 20
+dynsec addRoleACL zmqtt-tests unsubscribePattern '#' allow 10
+dynsec addRoleACL zmqtt-tests unsubscribePattern 'zmqtt/unsuback/denied/#' deny 20
+
+wait "$broker_pid"

--- a/docker/start-mosquitto-dynsec.sh
+++ b/docker/start-mosquitto-dynsec.sh
@@ -13,29 +13,6 @@ chmod 640 "$config_file"
 mosquitto -c /mosquitto/config/mosquitto-dynsec.conf &
 broker_pid=$!
 
-attempt=0
-until mosquitto_ctrl -h 127.0.0.1 -p 1883 -u admin -P admin dynsec getClient admin >/dev/null 2>&1; do
-    attempt=$((attempt + 1))
-    if [ "$attempt" -ge 30 ]; then
-        echo "Mosquitto Dynamic Security did not become ready" >&2
-        exit 1
-    fi
-    sleep 1
-done
-
-dynsec() {
-    mosquitto_ctrl -h 127.0.0.1 -p 1883 -u admin -P admin dynsec "$@"
-}
-
-dynsec setDefaultACLAccess publishClientSend allow
-dynsec setDefaultACLAccess subscribe allow
-dynsec createClient zmqtt-mosquitto -p zmqtt-mosquitto
-dynsec createRole zmqtt-tests
-dynsec addClientRole zmqtt-mosquitto zmqtt-tests 10
-dynsec addRoleACL zmqtt-tests subscribePattern '#' allow 10
-dynsec addRoleACL zmqtt-tests publishClientSend '#' allow 10
-dynsec addRoleACL zmqtt-tests publishClientSend 'zmqtt/e2e/denied' deny 20
-dynsec addRoleACL zmqtt-tests unsubscribePattern '#' allow 10
-dynsec addRoleACL zmqtt-tests unsubscribePattern 'zmqtt/unsuback/denied/#' deny 20
+/bin/sh /mosquitto/config/dynsec-bootstrap.sh
 
 wait "$broker_pid"

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -49,6 +49,10 @@
     options:
       show_source: false
 
+::: zmqtt.UnsubscribeResult
+    options:
+      show_source: false
+
 ## Configuration
 
 ::: zmqtt.client.ReconnectConfig
@@ -82,6 +86,10 @@
       show_source: false
 
 ::: zmqtt.ConnAckProperties
+    options:
+      show_source: false
+
+::: zmqtt.UnsubAckProperties
     options:
       show_source: false
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -91,6 +91,8 @@ except MQTTSubscribeError as e:
 
 The same exception is raised by `await sub.start()` when using the manual subscription lifecycle.
 
+A rejected UNSUBSCRIBE is not an exception — see [Manual subscription lifecycle](subscribing.md#manual-subscription-lifecycle).
+
 ### `MQTTPublishError`
 
 Raised on a `version="5.0"` connection when the broker rejects a QoS 1 or QoS 2

--- a/docs/subscribing.md
+++ b/docs/subscribing.md
@@ -24,7 +24,16 @@ async for msg in sub:
 await sub.stop()
 ```
 
-`stop()` sends UNSUBSCRIBE and releases internal resources. It is safe to call even if the connection has already been lost.
+`stop()` sends UNSUBSCRIBE, stops message delivery and returns the broker's UNSUBACK as an `UnsubscribeResult`, or `None` if none was received — for example after the connection was lost. It never raises: failures and rejections are logged as warnings. Exiting `async with` does the same and discards the result.
+
+On MQTT 5.0 the broker may reject some filters (reason code `0x80` or above); they are listed in `failures`. The subscription stops anyway, but the broker may keep sending messages on a rejected filter — on a persistent session, across reconnects too.
+
+```python
+result = await sub.stop()
+if result is not None:
+    for topic_filter, reason_code in result.failures.items():
+        print(f"{topic_filter!r} rejected: 0x{reason_code:02X}")
+```
 
 ### Buffering and backpressure
 

--- a/src/zmqtt/__init__.py
+++ b/src/zmqtt/__init__.py
@@ -4,6 +4,7 @@ from zmqtt._internal.packets.properties import (
     ConnAckProperties,
     ConnectProperties,
     PublishProperties,
+    UnsubAckProperties,
     WillProperties,
 )
 from zmqtt._internal.topic_matching import topic_matches
@@ -17,6 +18,7 @@ from zmqtt.client import (
     MQTTClientV311,
     ReconnectConfig,
     Subscription,
+    UnsubscribeResult,
     create_client,
 )
 from zmqtt.errors import (
@@ -54,6 +56,8 @@ __all__ = (
     "ReconnectConfig",
     "RetainHandling",
     "Subscription",
+    "UnsubAckProperties",
+    "UnsubscribeResult",
     "Will",
     "WillProperties",
     "create_client",

--- a/src/zmqtt/_internal/protocol.py
+++ b/src/zmqtt/_internal/protocol.py
@@ -60,6 +60,15 @@ _PUBLISH_REASON_NAMES: Final[dict[int, str]] = {
     0x99: "Payload format invalid",
 }
 
+# MQTT 5.0 §3.11.3
+_UNSUBACK_REASON_NAMES: Final[dict[int, str]] = {
+    0x80: "Unspecified error",
+    0x83: "Implementation specific error",
+    0x87: "Not authorized",
+    0x8F: "Topic Filter invalid",
+    0x91: "Packet Identifier in use",
+}
+
 
 class _SubscriptionGuard:
     def __init__(self) -> None:
@@ -108,16 +117,6 @@ def _raise_on_rejected_filters(filters: list[SubscriptionRequest], suback: SubAc
     failures = {req.topic_filter: code for req, code in zip(filters, suback.return_codes, strict=False) if code >= 0x80}
     if failures:
         raise MQTTSubscribeError(failures)
-
-
-# MQTT 5.0 §3.11.3
-_UNSUBACK_REASON_NAMES: Final[dict[int, str]] = {
-    0x80: "Unspecified error",
-    0x83: "Implementation specific error",
-    0x87: "Not authorized",
-    0x8F: "Topic Filter invalid",
-    0x91: "Packet Identifier in use",
-}
 
 
 def _warn_on_rejected_unsubscribe(filters: list[str], unsuback: UnsubAck) -> None:
@@ -427,18 +426,15 @@ class MQTTProtocol:
         for f in filters:
             self._state.subscriptions.remove(f)
 
-        unsuback = await self._send_unsubscribe(broker_filters) if broker_filters else None
-        if unsuback is not None:
+        acknowledged = None
+        if broker_filters:
+            unsuback = await self._send_unsubscribe(broker_filters)
             _warn_on_rejected_unsubscribe(broker_filters, unsuback)
+            acknowledged = (tuple(broker_filters), unsuback)
         if observed_filters:
             requests = [SubscriptionRequest(topic_filter=f, qos=QoS.AT_MOST_ONCE) for f in observed_filters]
             await self._send_subscribe(requests, subscription_identifier=None)
-        if unsuback is None:
-            return None
-        if self._version == "5.0" and len(unsuback.reason_codes) != len(broker_filters):
-            msg = f"UNSUBACK carries {len(unsuback.reason_codes)} reason codes for {len(broker_filters)} filters"
-            raise MQTTProtocolError(msg)
-        return tuple(broker_filters), unsuback
+        return acknowledged
 
     async def add_response_observer(self, topic: str) -> None:
         """Keep an exact response topic subscribed for pending requests."""

--- a/src/zmqtt/_internal/protocol.py
+++ b/src/zmqtt/_internal/protocol.py
@@ -110,6 +110,32 @@ def _raise_on_rejected_filters(filters: list[SubscriptionRequest], suback: SubAc
         raise MQTTSubscribeError(failures)
 
 
+# MQTT 5.0 §3.11.3
+_UNSUBACK_REASON_NAMES: Final[dict[int, str]] = {
+    0x80: "Unspecified error",
+    0x83: "Implementation specific error",
+    0x87: "Not authorized",
+    0x8F: "Topic Filter invalid",
+    0x91: "Packet Identifier in use",
+}
+
+
+def _warn_on_rejected_unsubscribe(filters: list[str], unsuback: UnsubAck) -> None:
+    rejected = [
+        f"{f!r} (0x{code:02X} {_UNSUBACK_REASON_NAMES.get(code, 'Unknown')})"
+        for f, code in zip(filters, unsuback.reason_codes, strict=False)
+        if code >= 0x80
+    ]
+    if not rejected:
+        return
+    reason_string = unsuback.properties.reason_string if unsuback.properties is not None else None
+    log.warning(
+        "Broker rejected unsubscribe of %s%s; it may keep delivering messages on these filters",
+        ", ".join(rejected),
+        f" ({reason_string})" if reason_string else "",
+    )
+
+
 def _publish_error(packet: PubAck | PubRec) -> MQTTPublishError:
     return MQTTPublishError(
         packet.reason_code,
@@ -384,16 +410,17 @@ class MQTTProtocol:
                 for f in new_entries:
                     self._state.subscriptions.remove(f)
 
-    async def unsubscribe(self, filters: list[str]) -> UnsubAck | None:
+    async def unsubscribe(self, filters: list[str]) -> tuple[tuple[str, ...], UnsubAck] | None:
         """Remove queues and unsubscribe filters without response observers.
 
-        Returns ``None`` when every broker subscription must stay active for
-        request/response routing.
+        Returns the filters sent to the broker with its UNSUBACK, or ``None``
+        when every broker subscription must stay active for request/response
+        routing.
         """
         async with self._subscription_guards.hold(filters):
             return await self._unsubscribe(filters)
 
-    async def _unsubscribe(self, filters: list[str]) -> UnsubAck | None:
+    async def _unsubscribe(self, filters: list[str]) -> tuple[tuple[str, ...], UnsubAck] | None:
         self._ensure_alive()
         observed_filters = [f for f in filters if self._state.subscriptions.has_response_observer(f)]
         broker_filters = [f for f in filters if f not in observed_filters]
@@ -401,10 +428,17 @@ class MQTTProtocol:
             self._state.subscriptions.remove(f)
 
         unsuback = await self._send_unsubscribe(broker_filters) if broker_filters else None
+        if unsuback is not None:
+            _warn_on_rejected_unsubscribe(broker_filters, unsuback)
         if observed_filters:
             requests = [SubscriptionRequest(topic_filter=f, qos=QoS.AT_MOST_ONCE) for f in observed_filters]
             await self._send_subscribe(requests, subscription_identifier=None)
-        return unsuback
+        if unsuback is None:
+            return None
+        if self._version == "5.0" and len(unsuback.reason_codes) != len(broker_filters):
+            msg = f"UNSUBACK carries {len(unsuback.reason_codes)} reason codes for {len(broker_filters)} filters"
+            raise MQTTProtocolError(msg)
+        return tuple(broker_filters), unsuback
 
     async def add_response_observer(self, topic: str) -> None:
         """Keep an exact response topic subscribed for pending requests."""
@@ -436,7 +470,8 @@ class MQTTProtocol:
             return
         if self._state.subscriptions.contains(topic) or self._dead:
             return
-        await self._send_unsubscribe([topic])
+        unsuback = await self._send_unsubscribe([topic])
+        _warn_on_rejected_unsubscribe([topic], unsuback)
 
     async def _send_subscribe(
         self,

--- a/src/zmqtt/_internal/protocol.py
+++ b/src/zmqtt/_internal/protocol.py
@@ -433,7 +433,10 @@ class MQTTProtocol:
             acknowledged = (tuple(broker_filters), unsuback)
         if observed_filters:
             requests = [SubscriptionRequest(topic_filter=f, qos=QoS.AT_MOST_ONCE) for f in observed_filters]
-            await self._send_subscribe(requests, subscription_identifier=None)
+            try:
+                await self._send_subscribe(requests, subscription_identifier=None)
+            except Exception:  # noqa: BLE001 - must not discard the UNSUBACK already received
+                log.warning("Restoring response observers %s failed", observed_filters, exc_info=True)
         return acknowledged
 
     async def add_response_observer(self, topic: str) -> None:

--- a/src/zmqtt/client.py
+++ b/src/zmqtt/client.py
@@ -18,9 +18,10 @@ from zmqtt._internal.packets.properties import (
     ConnAckProperties,
     ConnectProperties,
     PublishProperties,
+    UnsubAckProperties,
 )
 from zmqtt._internal.packets.publish import Publish
-from zmqtt._internal.packets.subscribe import SubscriptionRequest
+from zmqtt._internal.packets.subscribe import SubscriptionRequest, UnsubAck
 from zmqtt._internal.protocol import MQTTProtocol
 from zmqtt._internal.request_response import _RequestDispatcher
 from zmqtt._internal.state import SessionState
@@ -42,6 +43,7 @@ __all__ = (
     "ReconnectConfig",
     "Subscription",
     "Transport",
+    "UnsubscribeResult",
     "create_client",
 )
 
@@ -49,6 +51,8 @@ TransportFactory = Callable[[str, int, ssl.SSLContext | bool | None], Awaitable[
 
 # MQTT 5.0 §3.8.2.1.2: a subscription identifier is a variable-byte integer.
 _MAX_SUBSCRIPTION_IDENTIFIER = 268_435_455
+
+_UNSUBACK_REJECTION_THRESHOLD: Final = 0x80
 
 log = logging.getLogger(__name__)
 
@@ -111,6 +115,43 @@ class ConnectionInfo:
             effective_keepalive=keepalive,
             effective_session_expiry_interval=expiry,
         )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class UnsubscribeResult:
+    """The broker's UNSUBACK for the filters sent in one UNSUBSCRIBE.
+
+    Attributes:
+        topic_filters: Filters sent to the broker, in request order.
+        reason_codes: One code per filter. Empty on MQTT 3.1.1, whose UNSUBACK
+            carries none.
+        properties: Raw UNSUBACK properties.
+    """
+
+    topic_filters: tuple[str, ...]
+    reason_codes: tuple[int, ...]
+    properties: UnsubAckProperties | None
+
+    @classmethod
+    def from_unsuback(cls, topic_filters: tuple[str, ...], unsuback: UnsubAck) -> Self:
+        return cls(topic_filters=topic_filters, reason_codes=unsuback.reason_codes, properties=unsuback.properties)
+
+    @property
+    def failures(self) -> dict[str, int]:
+        """Rejected filters mapped to their reason codes (>= 0x80)."""
+        return {
+            f: code
+            for f, code in zip(self.topic_filters, self.reason_codes, strict=False)
+            if code >= _UNSUBACK_REJECTION_THRESHOLD
+        }
+
+    @property
+    def reason_string(self) -> str | None:
+        return self.properties.reason_string if self.properties is not None else None
+
+    @property
+    def user_properties(self) -> tuple[tuple[str, str], ...]:
+        return self.properties.user_properties if self.properties is not None else ()
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -273,12 +314,22 @@ class Subscription:
         return self
 
     async def __aexit__(self, *exc: object) -> None:
-        """Unsubscribe from all filters and stop message delivery."""
+        """Same as :meth:`stop`, discarding its result; skips UNSUBSCRIBE if the body was cancelled."""
+        await self._stop(cancelled=isinstance(exc[1], asyncio.CancelledError))
+
+    async def _stop(self, *, cancelled: bool) -> UnsubscribeResult | None:
+        if self not in self._client._subscriptions:
+            return None
         self._client._subscriptions.remove(self)
-        being_cancelled = isinstance(exc[1], asyncio.CancelledError)
-        if not being_cancelled and self._registered_filters and self._client._protocol is not None:
-            with contextlib.suppress(Exception):
-                await self._client._protocol.unsubscribe(self._registered_filters)
+        protocol = self._client._protocol
+        if cancelled or not self._registered_filters or protocol is None:
+            return None
+        try:
+            sent = await protocol.unsubscribe(self._registered_filters)
+        except Exception:  # noqa: BLE001 - filters are already released locally, so nothing is left to retry
+            log.warning("Unsubscribe of %s failed; stopped locally", self._registered_filters, exc_info=True)
+            return None
+        return UnsubscribeResult.from_unsuback(*sent) if sent is not None else None
 
     async def _do_subscribe(self, protocol: MQTTProtocol) -> None:
         reqs = [
@@ -321,18 +372,21 @@ class Subscription:
         """
         await self.__aenter__()
 
-    async def stop(self) -> None:
+    async def stop(self) -> UnsubscribeResult | None:
         """Unsubscribe from all filters and stop message delivery.
 
         Equivalent to exiting the async context manager. Sends UNSUBSCRIBE to
-        the broker. Safe to call even if the connection has already been lost —
-        the UNSUBSCRIBE is silently skipped in that case.
+        the broker. Never raises: failures and rejected filters are logged as
+        warnings.
 
         Example::
 
             await sub.stop()
+
+        Returns:
+            The broker's UNSUBACK, or ``None`` if none was received.
         """
-        await self.__aexit__(None, None, None)
+        return await self._stop(cancelled=False)
 
     async def get_message(self) -> Message:
         """Wait for and return the next message from the subscription queue.

--- a/tests/test_brokers/_base.py
+++ b/tests/test_brokers/_base.py
@@ -7,6 +7,7 @@ Run with:  pytest -m broker
 import abc
 import asyncio
 import contextlib
+import logging
 import ssl
 import uuid
 from collections.abc import AsyncGenerator
@@ -185,6 +186,52 @@ class BrokerTestBase(abc.ABC):
 
         message = await asyncio.wait_for(concrete.get_message(), timeout=5.0)
         assert message.payload == b"exact-remains"
+
+    async def test_stop_returns_broker_acknowledgement(self, mqtt_client: MQTTClient, topic: str) -> None:
+        sub = mqtt_client.subscribe(f"{topic}/a", f"{topic}/b")
+        await sub.start()
+
+        result = await sub.stop()
+
+        assert result is not None
+        assert result.topic_filters == (f"{topic}/a", f"{topic}/b")
+        assert result.reason_codes == ((0x00, 0x00) if self.version == "5.0" else ())
+        assert result.failures == {}
+
+    async def test_stop_after_disconnect_returns_none(self, mqtt_client: MQTTClient, topic: str) -> None:
+        sub = mqtt_client.subscribe(topic)
+        await sub.start()
+        await mqtt_client.disconnect()
+
+        result = await sub.stop()
+
+        assert result is None
+
+    async def test_repeated_stop_returns_none(self, mqtt_client: MQTTClient, topic: str) -> None:
+        sub = mqtt_client.subscribe(topic)
+        await sub.start()
+        await sub.stop()
+
+        result = await sub.stop()
+
+        assert result is None
+
+    async def test_stop_after_connection_loss_logs_failure(self, topic: str, caplog: pytest.LogCaptureFixture) -> None:
+        async with MQTTClient(
+            self.host,
+            self.port,
+            reconnect=ReconnectConfig(enabled=False),
+            version=self.version,
+        ) as client:
+            sub = client.subscribe(topic)
+            await sub.start()
+            await self.force_tcp_disconnect(client)
+
+            with caplog.at_level(logging.WARNING, logger="zmqtt.client"):
+                result = await sub.stop()
+
+        assert result is None
+        assert any(record.exc_info for record in caplog.records if record.name == "zmqtt.client")
 
     async def test_unsubscribe_identifier_preserves_other_subscription(
         self,
@@ -1006,7 +1053,7 @@ class BrokerTestBase(abc.ABC):
             )
             request = await asyncio.wait_for(req_sub.get_message(), timeout=5.0)
             assert request.properties is not None
-            await response_sub.stop()
+            result = await response_sub.stop()
             await responder.publish(
                 response_topic,
                 b"response-after-stop",
@@ -1016,7 +1063,43 @@ class BrokerTestBase(abc.ABC):
             )
             reply = await request_task
 
+        assert result is None
         assert reply.payload == b"response-after-stop"
+
+    async def test_stop_reports_only_filters_sent_to_broker(self, topic: str) -> None:
+        if self.version != "5.0":
+            pytest.skip("request() requires MQTT 5.0")
+        response_topic = f"{topic}/responses"
+        other_filter = f"{topic}/other"
+        async with (
+            MQTTClient(self.host, self.port, version=self.version) as requester,
+            MQTTClient(self.host, self.port, version=self.version) as responder,
+            responder.subscribe(topic) as requests,
+        ):
+            response_sub = requester.subscribe(response_topic, other_filter)
+            await response_sub.start()
+            request_task = asyncio.create_task(
+                requester.request(
+                    topic,
+                    b"request",
+                    properties=PublishProperties(response_topic=response_topic),
+                    timeout=5.0,
+                ),
+            )
+            request = await asyncio.wait_for(requests.get_message(), timeout=5.0)
+            assert request.properties is not None
+
+            result = await response_sub.stop()
+            await responder.publish(
+                response_topic,
+                b"reply",
+                properties=PublishProperties(correlation_data=request.properties.correlation_data),
+            )
+            reply = await request_task
+
+        assert result is not None
+        assert result.topic_filters == (other_filter,)
+        assert reply.payload == b"reply"
 
     async def test_request_backpressure_delays_publish(self, topic: str) -> None:
         if self.version != "5.0":

--- a/tests/test_brokers/test_mosquitto.py
+++ b/tests/test_brokers/test_mosquitto.py
@@ -1,10 +1,13 @@
 import asyncio
+import logging
 import re
+import uuid
+from collections.abc import AsyncGenerator
 
 import pytest
 
 from tests.test_brokers._base import BrokerTestBase
-from zmqtt import Subscription
+from zmqtt import PublishProperties, Subscription
 from zmqtt._internal.types.qos import QoS
 from zmqtt.client import MQTTClient
 from zmqtt.errors import MQTTPublishError
@@ -12,6 +15,21 @@ from zmqtt.errors import MQTTPublishError
 
 class BaseTestMosquitto(BrokerTestBase):
     denied_topic = "zmqtt/e2e/denied"
+    # Dynamic Security grants this client the ACLs the rejection tests rely on.
+    username = "zmqtt-mosquitto"
+    password = "zmqtt-mosquitto"  # noqa: S105
+
+    @pytest.fixture
+    async def mqtt_client(self) -> AsyncGenerator[MQTTClient]:
+        async with MQTTClient(
+            self.host,
+            self.port,
+            client_id=f"zmqtt-test-{uuid.uuid4().hex[:8]}",
+            username=self.username,
+            password=self.password,
+            version=self.version,
+        ) as client:
+            yield client
 
     async def handle_sub_duplicates(
         self,
@@ -45,6 +63,22 @@ class TestMosquittoV311(BaseTestMosquitto):
 
         assert msg.topic == topic
         assert msg.payload == b"payload-qos0"
+
+    async def test_stop_on_rejecting_broker_reports_no_reason_codes(
+        self,
+        mqtt_client: MQTTClient,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        denied_filter = f"zmqtt/unsuback/denied/{uuid.uuid4().hex}"
+        sub = mqtt_client.subscribe(denied_filter)
+        await sub.start()
+
+        with caplog.at_level(logging.WARNING, logger="zmqtt.protocol"):
+            result = await sub.stop()
+
+        assert result is not None
+        assert result.reason_codes == ()
+        assert "Broker rejected unsubscribe" not in caplog.text
 
 
 class TestMosquittoV5(BaseTestMosquitto):
@@ -82,3 +116,86 @@ class TestMosquittoV5(BaseTestMosquitto):
 
         assert msg.topic == topic
         assert msg.payload == b"payload-qos0"
+
+    async def test_stop_reports_rejected_filter(self, mqtt_client: MQTTClient) -> None:
+        suffix = uuid.uuid4().hex
+        allowed_filter = f"zmqtt/unsuback/allowed/{suffix}"
+        denied_filter = f"zmqtt/unsuback/denied/{suffix}"
+        sub = mqtt_client.subscribe(allowed_filter, denied_filter)
+        await sub.start()
+
+        result = await sub.stop()
+
+        assert result is not None
+        assert result.topic_filters == (allowed_filter, denied_filter)
+        assert result.reason_codes == (0x00, 0x87)
+        assert result.failures == {denied_filter: 0x87}
+        assert result.reason_string is None  # this broker sends no diagnostic
+
+    async def test_stop_logs_rejected_filter(self, mqtt_client: MQTTClient, caplog: pytest.LogCaptureFixture) -> None:
+        denied_filter = f"zmqtt/unsuback/denied/{uuid.uuid4().hex}"
+        sub = mqtt_client.subscribe(denied_filter)
+        await sub.start()
+
+        with caplog.at_level(logging.WARNING, logger="zmqtt.protocol"):
+            await sub.stop()
+
+        assert f"{denied_filter!r} (0x87 Not authorized)" in caplog.text
+
+    async def test_rejected_filter_stops_delivering_to_subscription(self, mqtt_client: MQTTClient) -> None:
+        denied_filter = f"zmqtt/unsuback/denied/{uuid.uuid4().hex}"
+        sub = mqtt_client.subscribe(denied_filter, qos=QoS.AT_LEAST_ONCE)
+        await sub.start()
+        await sub.stop()
+
+        await mqtt_client.publish(denied_filter, b"after-stop", qos=QoS.AT_LEAST_ONCE)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(sub.get_message(), timeout=0.5)
+
+    async def test_rejected_unsubscribe_keeps_body_exception(
+        self,
+        mqtt_client: MQTTClient,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        denied_filter = f"zmqtt/unsuback/denied/{uuid.uuid4().hex}"
+        body_error = RuntimeError("body failed")
+
+        with caplog.at_level(logging.WARNING, logger="zmqtt.protocol"), pytest.raises(RuntimeError) as exc_info:
+            async with mqtt_client.subscribe(denied_filter):
+                raise body_error
+
+        assert exc_info.value is body_error
+        assert f"{denied_filter!r} (0x87 Not authorized)" in caplog.text
+
+    async def test_rejected_response_topic_release_is_logged(
+        self,
+        mqtt_client: MQTTClient,
+        topic: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        response_topic = f"zmqtt/unsuback/denied/{uuid.uuid4().hex}"
+        async with (
+            MQTTClient(self.host, self.port, version=self.version) as responder,
+            responder.subscribe(topic) as requests,
+        ):
+            request_task = asyncio.create_task(
+                mqtt_client.request(
+                    topic,
+                    b"request",
+                    properties=PublishProperties(response_topic=response_topic),
+                    timeout=5.0,
+                ),
+            )
+            request = await asyncio.wait_for(requests.get_message(), timeout=5.0)
+            assert request.properties is not None
+
+            with caplog.at_level(logging.WARNING, logger="zmqtt.protocol"):
+                await responder.publish(
+                    response_topic,
+                    b"reply",
+                    properties=PublishProperties(correlation_data=request.properties.correlation_data),
+                )
+                await request_task
+
+        assert f"{response_topic!r} (0x87 Not authorized)" in caplog.text

--- a/tests/test_brokers/test_mosquitto.py
+++ b/tests/test_brokers/test_mosquitto.py
@@ -117,39 +117,25 @@ class TestMosquittoV5(BaseTestMosquitto):
         assert msg.topic == topic
         assert msg.payload == b"payload-qos0"
 
-    async def test_stop_reports_rejected_filter(self, mqtt_client: MQTTClient) -> None:
+    async def test_stop_reports_rejected_filter(
+        self, mqtt_client: MQTTClient, caplog: pytest.LogCaptureFixture
+    ) -> None:
         suffix = uuid.uuid4().hex
         allowed_filter = f"zmqtt/unsuback/allowed/{suffix}"
         denied_filter = f"zmqtt/unsuback/denied/{suffix}"
         sub = mqtt_client.subscribe(allowed_filter, denied_filter)
         await sub.start()
 
-        result = await sub.stop()
+        with caplog.at_level(logging.WARNING, logger="zmqtt.protocol"):
+            result = await sub.stop()
 
         assert result is not None
         assert result.topic_filters == (allowed_filter, denied_filter)
         assert result.reason_codes == (0x00, 0x87)
         assert result.failures == {denied_filter: 0x87}
         assert result.reason_string is None  # this broker sends no diagnostic
-
-    async def test_stop_logs_rejected_filter(self, mqtt_client: MQTTClient, caplog: pytest.LogCaptureFixture) -> None:
-        denied_filter = f"zmqtt/unsuback/denied/{uuid.uuid4().hex}"
-        sub = mqtt_client.subscribe(denied_filter)
-        await sub.start()
-
-        with caplog.at_level(logging.WARNING, logger="zmqtt.protocol"):
-            await sub.stop()
-
         assert f"{denied_filter!r} (0x87 Not authorized)" in caplog.text
-
-    async def test_rejected_filter_stops_delivering_to_subscription(self, mqtt_client: MQTTClient) -> None:
-        denied_filter = f"zmqtt/unsuback/denied/{uuid.uuid4().hex}"
-        sub = mqtt_client.subscribe(denied_filter, qos=QoS.AT_LEAST_ONCE)
-        await sub.start()
-        await sub.stop()
-
-        await mqtt_client.publish(denied_filter, b"after-stop", qos=QoS.AT_LEAST_ONCE)
-
+        # assert it stop's delivering
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(sub.get_message(), timeout=0.5)
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -12,13 +12,13 @@ from typing import Literal
 
 import pytest
 
-from zmqtt._internal.packets.codec import encode
+from zmqtt._internal.packets.codec import AnyPacket, encode
 from zmqtt._internal.packets.connect import ConnAck, Connect
 from zmqtt._internal.packets.disconnect import Disconnect
 from zmqtt._internal.packets.properties import PublishProperties
 from zmqtt._internal.packets.publish import PubAck, Publish, PubRec, PubRel
 from zmqtt._internal.packets.reader import PacketBuffer
-from zmqtt._internal.packets.subscribe import SubAck, Subscribe, SubscriptionRequest
+from zmqtt._internal.packets.subscribe import SubAck, Subscribe, SubscriptionRequest, UnsubAck
 from zmqtt._internal.protocol import (
     _PUBLISH_REASON_NAMES,
     MQTTProtocol,
@@ -537,6 +537,31 @@ async def test_suback_failure_rolls_back_subscription_index() -> None:
 
     assert not protocol._state.subscriptions.contains("denied/topic")
     assert protocol._state.subscriptions.by_identifier(7) == []
+
+
+async def _answer_after(transport: FakeTransport, *, sent: int, packet: AnyPacket) -> None:
+    while len(transport.sent) < sent:  # noqa: ASYNC110
+        await asyncio.sleep(0)
+    transport.feed(encode(packet, version="5.0"))
+
+
+async def test_failed_observer_resubscribe_keeps_unsuback(caplog: pytest.LogCaptureFixture) -> None:
+    protocol, transport = make_protocol(version="5.0")
+    protocol._state.subscriptions.add_many({f: SubscriptionEntry(queue=asyncio.Queue()) for f in ("reply", "events/#")})
+    protocol._state.subscriptions.add_response_observer("reply")
+    read = await _run_read_loop(protocol)
+
+    with caplog.at_level(logging.WARNING, logger="zmqtt.protocol"):
+        unsubscribing = asyncio.create_task(protocol.unsubscribe(["reply", "events/#"]))
+        await _answer_after(transport, sent=1, packet=UnsubAck(packet_id=1, reason_codes=(0x00,)))
+        await _answer_after(transport, sent=2, packet=SubAck(packet_id=1, return_codes=(0x87,)))
+        acknowledged = await unsubscribing
+    await _stop_task(read)
+
+    assert acknowledged is not None
+    assert acknowledged[0] == ("events/#",)
+    assert acknowledged[1].reason_codes == (0x00,)
+    assert any(record.exc_info and "reply" in record.getMessage() for record in caplog.records)
 
 
 async def test_inbound_qos2_manual_ack_duplicate_ignored() -> None:


### PR DESCRIPTION
## Summary

Resolves #81

- A rejected unsubscribe is logged as a WARNING, not raised. The subscription is released locally either way, as before. The same WARNING covers the release of a `request()` response topic.
- `stop()` and `async with` exit still never raise, but failures are now logged with `exc_info` instead of being swallowed. A repeated `stop()` no longer raises `ValueError`.


## I also found some bugs on master

1. **`stop()` hangs when the subscription buffer is full.** Subscribe with `receive_buffer_size=1`, publish 3 QoS 1 messages to that filter without reading them, then call `await sub.stop()`. It never returns: the single read loop is blocked on `queue.put` and cannot read the UNSUBACK.
2. **A cancelled consumer leaks its filters.** Cancel a task blocked in `async with client.subscribe("t") as sub: await sub.get_message()`. No UNSUBSCRIBE is sent and `"t"` stays in the local index. Messages pile up in the dead queue, and a new `client.subscribe("t")` logs "already subscribed (ignored)" and never receives anything.
3. **A resumed persistent session starves on unmatched messages.** On Mosquitto with `clean_session=False`, subscribe to a filter the broker refuses to unsubscribe, stop the subscription, and reconnect (`session_present=True`).
   - QoS 1: 30 messages on that filter stop QoS 1 delivery for every subscription on the connection. They are held without PUBACK and dropped after `session_replay_timeout`, still unacknowledged.
   - QoS 0: going over `session_replay_buffer_size` aborts the connection with `MQTTProtocolError`.

This applies to any filter left in the broker session without a local subscription.

- [x] Tests were added or updated when behavior changed
- [x] Documentation was updated when the public API changed
- [x] The PR title follows Conventional Commits, for example `feat(client): add reconnect timeout`
